### PR TITLE
update cards to be even size

### DIFF
--- a/src/Assets/scss/main.scss
+++ b/src/Assets/scss/main.scss
@@ -683,7 +683,7 @@ body {
             @include border-radius(8px);
             background: $color-white;
             @include box-shadow(0px, 4px, 8px, $shadow-color);
-            margin-bottom: 15px;
+            min-height: 100%;
             .custom-button,
             .default-button {
                 padding-left: inherit;
@@ -720,6 +720,7 @@ body {
             }
             .day-view-item-details {
                 padding: 1rem;
+                min-height: 280px;
 
                 .registration-required {
                     margin: 5px 0;

--- a/src/Modules/Events/EventCardComponent.js
+++ b/src/Modules/Events/EventCardComponent.js
@@ -25,7 +25,7 @@ const EventCardComponent = (props) => {
   } = props;
 
   return (
-    <div className="col-lg-4 col-xl-4">
+    <div className="col-lg-4 col-xl-4 mb-3">
       <div className="day-view-item">
         <div className="day-view-item-header">
           <div className="day-view-header-title">{agencyName}</div>
@@ -34,7 +34,7 @@ const EventCardComponent = (props) => {
             <div className="day-view-item-name">{eventService}</div>
           </div>
         </div>
-        <div className="day-view-item-details">
+        <div className="day-view-item-details d-flex flex-column justify-content-between">
           {/* <div className="registration-required">
               <span className="registration-required-label">Registration Required</span>
             </div> */}


### PR DESCRIPTION
Your PR exposed an issue with the original styling. This updates the cards to be equal heights.

<img width="600" alt="Screen Shot 2020-05-22 at 3 23 41 PM" src="https://user-images.githubusercontent.com/18721340/82702554-3c327080-9c40-11ea-8fae-4263822eefe1.png">
<img width="600" alt="Screen Shot 2020-05-22 at 3 22 50 PM" src="https://user-images.githubusercontent.com/18721340/82702559-3e94ca80-9c40-11ea-845e-0b8451050f24.png">


