### PR TITLE
Check if user phone number is set on registration confirmation

### DIFF
--- a/src/Modules/Family/RegistrationConfirmComponent.js
+++ b/src/Modules/Family/RegistrationConfirmComponent.js
@@ -48,9 +48,13 @@ const RegistrationConfirmComponent = (props) => {
 
   const formatPhoneNumber = (input) => {
     const regExp = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/
-    return (
-      input.replace(regExp, '($1) $2-$3')
-    )
+    if (input) {
+      return (
+        input.replace(regExp, '($1) $2-$3')
+      )
+    } else {
+      return '';
+    }
   }
 
   return (


### PR DESCRIPTION
This fixes a bug that prevents the confirmation page from rendering if the user doesn't have a phone number.