### PR TITLE
added scroll to container

### DIFF
--- a/src/Core/Routes.js
+++ b/src/Core/Routes.js
@@ -8,6 +8,7 @@ import {
   Route,
   Redirect,
 } from "react-router-dom";
+import ScrollContainer from "./ScrollContainer";
 const DashBoardContainer = lazy(() =>
   import("../Modules/Dashboard/DashBoardContainer")
 );
@@ -34,6 +35,7 @@ const Routes = () => {
 
   return (
     <Router basename="/">
+      <ScrollContainer />
       <Suspense fallback={<div className="displayNone"> </div>}>
         <WrapperComponent>
           <Switch>

--- a/src/Core/ScrollContainer.js
+++ b/src/Core/ScrollContainer.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0,0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,8 @@
 import '@testing-library/jest-dom/extend-expect';
 import 'mutationobserver-shim';
 
+window.scrollTo = () => {};
+
 window.google = {
   maps: {
     Marker: class {},


### PR DESCRIPTION
Scrolls to the top of the page on a `<Link />` route change.

Note, clicking the back button will not scroll to the top. That is [normal browser behavior.](https://reactrouter.com/web/guides/scroll-restoration)