### PR TITLE
refs #84 update source of Service Category

### DIFF
--- a/src/Testing/mock-events/index.js
+++ b/src/Testing/mock-events/index.js
@@ -27,6 +27,7 @@ export const mockEventsBuilder = build('Events').fields({
   event_details: fake(f => f.random.word()),
   event_dates: [],
   forms: [],
+  service_category: {}
 });
 
 export const mockEventDatesBuilder = build('EventDates').fields({
@@ -42,6 +43,11 @@ export const mockFormsBuilder = build('Forms').fields({
   id: fake(f => f.random.number()),
   display_age_senior: 60,
   display_age_adult: 18,
+});
+
+export const mockServiceCategoryBuilder = build('ServiceCategory').fields({
+  id: fake(f => f.random.number()),
+  service_category_name: fake(f => f.random.word())
 });
 
 export const mockEventHoursBuilder = build('EventHours').fields({
@@ -63,6 +69,7 @@ export const mockAgency = mockAgencyBuilder();
 export const mockEvent = mockEventsBuilder();
 export const mockEventDate = mockEventDatesBuilder();
 export const mockForms = mockFormsBuilder();
+export const mockServiceCategory = mockFormsBuilder();
 export const mockEventHour = mockEventHoursBuilder();
 export const mockEventSlot = mockEventSlotBuilder();
 

--- a/src/Utils/EventHandler.js
+++ b/src/Utils/EventHandler.js
@@ -47,7 +47,7 @@ const eventDateMapper = (event, phone, name, estimated_distance) => {
         phoneNumber: phone,
         agencyName: name,
         eventName: event.name,
-        eventService: event.service,
+        eventService: event.service_category['service_category_name'],
         estimated_distance,
         eventDetails: event.event_details,
         seniorAge: event.forms[0]["display_age_senior"],

--- a/src/Utils/__test__/EventHandler.test.js
+++ b/src/Utils/__test__/EventHandler.test.js
@@ -1,5 +1,5 @@
 import { EventHandler, EventObjectBuilder, AgencyHandler } from '../EventHandler';
-import { mockAgencyBuilder, mockEventsBuilder, mockEventDatesBuilder, mockFormsBuilder, mockAgency, mockEvent, mockEventDate, mockForms } from '../../Testing';
+import { mockAgencyBuilder, mockEventsBuilder, mockEventDatesBuilder, mockFormsBuilder, mockServiceCategoryBuilder, mockAgency, mockEvent, mockEventDate, mockForms, mockServiceCategory } from '../../Testing';
 
 test('should handle bad or empty data', () => {
   expect(EventHandler(null)).toEqual({});
@@ -11,6 +11,7 @@ test('should return an array of events', () => {
   const event1 = mockEventsBuilder();
   const eventDate1 = mockEventDatesBuilder();
   const form1 = mockFormsBuilder();
+  const service_category1 = mockServiceCategoryBuilder();
   const expected = [
     {
       id: eventDate1.id,
@@ -26,14 +27,14 @@ test('should return an array of events', () => {
       phoneNumber: agency1.phone,
       agencyName: agency1.name,
       eventName: event1.name,
-      eventService: event1.service,
+      eventService: service_category1.service_category_name,
       estimated_distance: agency1.estimated_distance,
       eventDetails: event1.event_details,
       seniorAge: form1.display_age_senior,
       adultAge: form1.display_age_adult
     }
   ];
-  const testData = [{ ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }] }] }];
+  const testData = [{ ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }], service_category: { ...service_category1 } }] }];
   expect(AgencyHandler(testData)).toEqual(expected);
 });
 
@@ -44,6 +45,7 @@ test('should return an array of events with mulitple agencies and one with no ev
   const event2 = mockEventsBuilder();
   const eventDate1 = mockEventDatesBuilder();
   const form1 = mockFormsBuilder();
+  const service_category1 = mockServiceCategoryBuilder();
   const expected = [
     {
       id: eventDate1.id,
@@ -59,7 +61,7 @@ test('should return an array of events with mulitple agencies and one with no ev
       phoneNumber: agency1.phone,
       agencyName: agency1.name,
       eventName: event1.name,
-      eventService: event1.service,
+      eventService: service_category1.service_category_name,
       estimated_distance: agency1.estimated_distance,
       eventDetails: event1.event_details,
       seniorAge: form1.display_age_senior,
@@ -67,7 +69,7 @@ test('should return an array of events with mulitple agencies and one with no ev
     }
   ];
   const testData = [
-    { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }] }] },
+    { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }], service_category: { ...service_category1 } }] },
     { ...agency2, events: [event2] },
   ];
   expect(AgencyHandler(testData)).toEqual(expected);
@@ -82,6 +84,8 @@ test('should return an array of events with multiple agencies and multiple event
   const eventDate2 = mockEventDatesBuilder();
   const form1 = mockFormsBuilder();
   const form2 = mockFormsBuilder();
+  const service_category1 = mockServiceCategoryBuilder();
+  const service_category2 = mockServiceCategoryBuilder();
   const expected = [
     {
       id: eventDate1.id,
@@ -97,7 +101,7 @@ test('should return an array of events with multiple agencies and multiple event
       phoneNumber: agency1.phone,
       agencyName: agency1.name,
       eventName: event1.name,
-      eventService: event1.service,
+      eventService: service_category1.service_category_name,
       estimated_distance: agency1.estimated_distance,
       eventDetails: event1.event_details,
       seniorAge: form1.display_age_senior,
@@ -117,7 +121,7 @@ test('should return an array of events with multiple agencies and multiple event
       phoneNumber: agency2.phone,
       agencyName: agency2.name,
       eventName: event2.name,
-      eventService: event2.service,
+      eventService: service_category2.service_category_name,
       estimated_distance: agency2.estimated_distance,
       eventDetails: event2.event_details,
       seniorAge: form2.display_age_senior,
@@ -125,8 +129,8 @@ test('should return an array of events with multiple agencies and multiple event
     }
   ];
   const testData = [
-    { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }] }] },
-    { ...agency2, events: [{ ...event2, event_dates: [{ ...eventDate2 }], forms: [{ ...form2 }] }] },
+    { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }], service_category: { ...service_category1 } }] },
+    { ...agency2, events: [{ ...event2, event_dates: [{ ...eventDate2 }], forms: [{ ...form2 }], service_category: { ...service_category2 } }] },
   ];
   expect(AgencyHandler(testData)).toEqual(expected);
 });
@@ -140,6 +144,8 @@ test('should sort events into dates', () => {
   const eventDate2 = mockEventDatesBuilder();
   const form1 = mockFormsBuilder();
   const form2 = mockFormsBuilder();
+  const service_category1 = mockServiceCategoryBuilder();
+  const service_category2 = mockServiceCategoryBuilder();
   const expected = {
     [eventDate1.date]: [
       {
@@ -156,7 +162,7 @@ test('should sort events into dates', () => {
         phoneNumber: agency1.phone,
         agencyName: agency1.name,
         eventName: event1.name,
-        eventService: event1.service,
+        eventService: service_category1.service_category_name,
         estimated_distance: agency1.estimated_distance,
         eventDetails: event1.event_details,
         seniorAge: form1.display_age_senior,
@@ -176,7 +182,7 @@ test('should sort events into dates', () => {
         phoneNumber: agency2.phone,
         agencyName: agency2.name,
         eventName: event2.name,
-        eventService: event2.service,
+        eventService: service_category2.service_category_name,
         estimated_distance: agency2.estimated_distance,
         eventDetails: event2.event_details,
         seniorAge: form2.display_age_senior,
@@ -187,8 +193,8 @@ test('should sort events into dates', () => {
   expect(
     EventObjectBuilder(
       AgencyHandler([
-        { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }] }] },
-        { ...agency2, events: [{ ...event2, event_dates: [{ ...eventDate2, date: eventDate1.date }], forms: [{ ...form2 }] }] },
+        { ...agency1, events: [{ ...event1, event_dates: [{ ...eventDate1 }], forms: [{ ...form1 }], service_category: { ...service_category1 } }] },
+        { ...agency2, events: [{ ...event2, event_dates: [{ ...eventDate2, date: eventDate1.date }], forms: [{ ...form2 }], service_category: { ...service_category2 } }] },
       ])
     )
   ).toEqual(expected);
@@ -201,7 +207,8 @@ test(`should return a final object sorted by events_date's date and distance`, (
     events: [
       { ...mockEvent,
         event_dates: [{ ...mockEventDate, date: '2020-04-01' }],
-        forms: [{ ...mockForms}]
+        forms: [{ ...mockForms}],
+        service_category: { ...mockServiceCategory }
       }
     ]
   };
@@ -216,7 +223,8 @@ test(`should return a final object sorted by events_date's date and distance`, (
         ],
         forms: [
           { ...mockForms}
-        ]
+        ],
+        service_category: { ...mockServiceCategory }
       }
     ]
   };
@@ -231,7 +239,8 @@ test(`should return a final object sorted by events_date's date and distance`, (
         ],
         forms: [
           { ...mockForms}
-        ]
+        ],
+        service_category: { ...mockServiceCategory }
       }
     ]
   };
@@ -248,7 +257,8 @@ test(`should return a final object sorted by events_date's date and distance`, (
         ],
         forms: [
           { ...mockForms}
-        ]
+        ],
+        service_category: { ...mockServiceCategory }
       }
     ]
   }
@@ -265,7 +275,7 @@ test(`should return a final object sorted by events_date's date and distance`, (
         eventId: mockEventDate.event_id,
         acceptReservations: mockEventDate.accept_reservations,
         eventName: mockEvent.name,
-        eventService: mockEvent.service,
+        eventService: mockServiceCategory.service_category_name,
         eventDetails: mockEvent.event_details,
         eventState: mockEvent.state,
         eventZip: mockEvent.zip,
@@ -287,7 +297,7 @@ test(`should return a final object sorted by events_date's date and distance`, (
         eventId: mockEventDate.event_id,
         acceptReservations: mockEventDate.accept_reservations,
         eventName: mockEvent.name,
-        eventService: mockEvent.service,
+        eventService: mockServiceCategory.service_category_name,
         eventDetails: mockEvent.event_details,
         eventState: mockEvent.state,
         eventZip: mockEvent.zip,
@@ -307,7 +317,7 @@ test(`should return a final object sorted by events_date's date and distance`, (
         eventId: mockEventDate.event_id,
         acceptReservations: mockEventDate.accept_reservations,
         eventName: mockEvent.name,
-        eventService: mockEvent.service,
+        eventService: mockServiceCategory.service_category_name,
         eventDetails: mockEvent.event_details,
         eventState: mockEvent.state,
         eventZip: mockEvent.zip,
@@ -327,7 +337,7 @@ test(`should return a final object sorted by events_date's date and distance`, (
         eventId: mockEventDate.event_id,
         acceptReservations: mockEventDate.accept_reservations,
         eventName: mockEvent.name,
-        eventService: mockEvent.service,
+        eventService: mockServiceCategory.service_category_name,
         eventDetails: mockEvent.event_details,
         eventState: mockEvent.state,
         eventZip: mockEvent.zip,


### PR DESCRIPTION
previously the Service Category is pulled from the "service:" field in the event JSON object in the pantry finder API results (agencies endpoint). 
Fixed: Now in this PR i updated to pull from the "service_category_name: " field in the service_category object (child of event)