### PR TITLE
update to use make new date

### DIFF
--- a/src/Modules/Family/RegistrationComponent.js
+++ b/src/Modules/Family/RegistrationComponent.js
@@ -8,7 +8,7 @@ import PrimaryInfoFormComponent from './PrimaryInfoFormComponent';
 import AddressComponent from './AddressComponent';
 import ContactInformationComponent from './ContactInformationComponent';
 import MemberCountFormComponent from './MemberCountFormComponent';
-import { formatDateToYYYYMMDD } from '../../Utils/DateFormat';
+import { formatDateForServer } from '../../Utils/DateFormat';
 
 const RegistrationComponent = ({ user, onRegister, event, disabled }) => {
   const { register, handleSubmit, errors, getValues, watch, reset, setValue } = useForm({mode: 'onChange'});
@@ -46,8 +46,9 @@ const RegistrationComponent = ({ user, onRegister, event, disabled }) => {
   }, [user, reset])
   const history = useHistory();
   const onSubmit = data => {
-    data["date_of_birth"] = formatDateToYYYYMMDD(data["date_of_birth"])
+    data["date_of_birth"] = formatDateForServer(data["date_of_birth"])
     onRegister(data);
+    // This must also be fixed. It is just luck that the params are available in the container
     if (data) {
       history.push({
         pathname: RENDER_URL.EVENT_REGISTRATION_URL + "/confirm"

--- a/src/Utils/DateFormat.js
+++ b/src/Utils/DateFormat.js
@@ -3,3 +3,8 @@ import moment from 'moment';
 export const formatDateDayAndDate = x => moment(x).format('dddd, M/D/YYYY');
 
 export const formatDateToYYYYMMDD = value => new Date(value).toISOString().split('T')[0];
+
+export const formatDateForServer = value => {
+  const formatted = value.split(' / ');
+  return new Date(formatted[2],formatted[0],formatted[1]).toISOString().split('T')[0];
+}


### PR DESCRIPTION
The issue seems to be that some browsers are able to create a new date and convert to ISO and some are not. 

This will split the date into it's individual sections (year, month, number of day in month) and create the ISO that way. 

We should still revisit this as I've found some issues with data persisting. The DOB comes back as '1984-08-16' but the client does not see that as valid. That is good for us now as this fix is fragile and only works for '08 / 16 / 1984'. But this should stop failing on mobile devices.