### PR TITLE
fixed data fetching logic where it was checking for data.data instead…

### DIFF
--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -127,12 +127,12 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
 	const getEvent = useCallback(async (): Promise<void> => {
 		try {
 			setLoading(true);
-			const resp = await axios.get<{ data: Event; errors?: string[] }>(
+			const resp = await axios.get<{ event: Event; errors?: string[] }>(
 				`${BASE_URL}api/event_dates/${eventDateId}/event_details`
 			);
 			const { data } = resp;
-			if (data && data.data) {
-				const eventData = EventFormat(data.data, eventDateId);
+			if (data && data.event) {
+				const eventData = EventFormat(data.event, eventDateId);
 				dispatch(setCurrentEvent(eventData));
 				setSelectedEvent(eventData);
 				setLoading(false);


### PR DESCRIPTION
User lands directly on /register/event/:id from external link
Redux store is empty (fresh session)
RegistrationEventDetailsContainer.getEvent() fetches data but only stores it locally (not in Redux):
   setSelectedEvent(EventFormat(data.event, eventDateId));  // Local state only!
User authenticates → navigates to /register/form/:id
RegistrationContainer initializes from Redux → empty
getEvent() IS called
The bug with data.data vs data.event is hit → Error page!