### PR TITLE
Ftw 748 prod hotfix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-	"presets": ["@babel/preset-env", "@babel/preset-react"]
+	"presets": [
+		"@babel/preset-env",
+		"@babel/preset-react",
+		"@babel/preset-typescript"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "homepage": "https://freshtrak.com",
   "dependencies": {

--- a/src/Modules/Family/__test__/ContactInformationComponent.test.tsx
+++ b/src/Modules/Family/__test__/ContactInformationComponent.test.tsx
@@ -8,9 +8,11 @@ jest.mock("../../Localization/LocalizationComponent", () => ({
 	register_how_to_contact: "How to Contact You",
 	phone_number: "Phone Number",
 	no_phone: "No Phone Available",
-	phone_contact_you: "Permission to text you",
+	phone_contact_you:
+		"I agree to receive SMS text message confirmations for my food pantry visit. Message & data rates may apply. Reply STOP to opt out.",
 	no_email: "No Email Available",
-	email_contact_you: "Permission to email you",
+	email_contact_you:
+		"I agree to receive email confirmations and updates about my food pantry visit.",
 	label_email: "Email",
 	error_phone_number_required: "Phone number is required",
 	error_email_required: "Email is required",
@@ -215,7 +217,9 @@ describe("ContactInformationComponent", () => {
 			renderComponent();
 
 			expect(
-				screen.getByText("Permission to text you")
+				screen.getByText(
+					"I agree to receive SMS text message confirmations for my food pantry visit. Message & data rates may apply. Reply STOP to opt out."
+				)
 			).toBeInTheDocument();
 			expect(screen.getByTestId("phone permission")).toBeInTheDocument();
 		});
@@ -311,7 +315,9 @@ describe("ContactInformationComponent", () => {
 			renderComponent();
 
 			expect(
-				screen.getByText("Permission to email you")
+				screen.getByText(
+					"I agree to receive email confirmations and updates about my food pantry visit."
+				)
 			).toBeInTheDocument();
 			expect(screen.getByTestId("email permission")).toBeInTheDocument();
 		});

--- a/src/Modules/Family/__test__/coreComponentsIntegration.test.tsx
+++ b/src/Modules/Family/__test__/coreComponentsIntegration.test.tsx
@@ -23,9 +23,11 @@ jest.mock("../../Localization/LocalizationComponent", () => ({
 	register_how_to_contact: "How to Contact You",
 	phone_number: "Phone Number",
 	no_phone: "No Phone Available",
-	phone_contact_you: "Permission to text you",
+	phone_contact_you:
+		"I agree to receive SMS text message confirmations for my food pantry visit. Message & data rates may apply. Reply STOP to opt out.",
 	no_email: "No Email Available",
-	email_contact_you: "Permission to email you",
+	email_contact_you:
+		"I agree to receive email confirmations and updates about my food pantry visit.",
 	label_email: "Email",
 	register_where_you_live: "Where do you live?",
 	street_address: "Street Address",

--- a/src/Modules/Family/__test__/responsiveDesignValidation.test.tsx
+++ b/src/Modules/Family/__test__/responsiveDesignValidation.test.tsx
@@ -22,9 +22,11 @@ jest.mock("../../Localization/LocalizationComponent", () => ({
 	register_how_to_contact: "How to Contact You",
 	phone_number: "Phone Number",
 	no_phone: "No Phone Available",
-	phone_contact_you: "Permission to text you",
+	phone_contact_you:
+		"I agree to receive SMS text message confirmations for my food pantry visit. Message & data rates may apply. Reply STOP to opt out.",
 	no_email: "No Email Available",
-	email_contact_you: "Permission to email you",
+	email_contact_you:
+		"I agree to receive email confirmations and updates about my food pantry visit.",
 	register_where_you_live: "Where do you live?",
 	street_address: "Street Address",
 	lot_suite: "Lot/Suite",

--- a/src/Modules/Localization/LocalizationComponent.js
+++ b/src/Modules/Localization/LocalizationComponent.js
@@ -57,12 +57,12 @@ let localization = new LocalizedStrings({
 		phone_number: "Phone Number (Mobile Preferred)",
 		no_phone: "No Phone Available",
 		phone_contact_you:
-			"Is it okay to contact you with updates and information about your registration, and updates to our network?",
+			"I agree to receive SMS text message confirmations for my food pantry visit. Message & data rates may apply. Reply STOP to opt out.",
 		no_email: "No Email Available",
 		label_no_email_question: "No Email?",
 		label_get_free_email: "Get one free from Google.",
 		email_contact_you:
-			"Is it okay to email you with updates and information about your registration, and updates to our network?",
+			"I agree to receive email confirmations and updates about my food pantry visit.",
 		register_about_family: "Tell us about your family",
 		family_count:
 			"How many additional family members are in each age group? (Do not include yourself)",
@@ -858,12 +858,12 @@ let localization = new LocalizedStrings({
 		phone_number: "Número de teléfono (móvil preferido)",
 		no_phone: "No hay teléfono disponible",
 		phone_contact_you:
-			"¿Está bien comunicarnos con usted con actualizaciones e información sobre su registro y actualizaciones de nuestra red?",
+			"Acepto recibir confirmaciones por mensaje de texto SMS para mi visita al banco de alimentos. Se pueden aplicar tarifas de mensajes y datos. Responda STOP para cancelar.",
 		no_email: "No hay correo electrónico disponible",
 		label_no_email_question: "¿No tiene correo electrónico?",
 		label_get_free_email: "Obtenga uno gratis de Google.",
 		email_contact_you:
-			"¿Está bien enviarle un correo electrónico con actualizaciones e información sobre su registro y actualizaciones de nuestra red?",
+			"Acepto recibir confirmaciones y actualizaciones por correo electrónico sobre mi visita al banco de alimentos.",
 		register_about_family: "Háblanos de tu familia",
 		family_count:
 			"¿Cuántos miembros adicionales de la familia hay en cada grupo de edad? (No te incluyas a ti mismo)",
@@ -1663,12 +1663,12 @@ let localization = new LocalizedStrings({
 		phone_number: "Lambarka taleefanka (Mobile doorbiday)",
 		no_phone: "Taleefan lamaheli karo",
 		phone_contact_you:
-			"Ma caadi baa inaan kula soo xiriiro cusbooneysiinta iyo macluumaadka ku saabsan diiwaangelintaada, iyo cusbooneysiinta shabakadeena?",
+			"Waxaan ogolahay inaan helo xaqiijinta fariin qoraal SMS ah ee booqashadayda kaydka cuntada. Khidmadaha fariimaha iyo xogta ayaa laga yaabaa inay khuseyso. Ku jawaab STOP si aad u joojiso.",
 		no_email: "Email Laheli Mayo",
 		label_no_email_question: "Email ma lihid?",
 		label_get_free_email: "Mid bilaash ah ka hel Google.",
 		email_contact_you:
-			"Ma caadi baa inaan kugu soo dirno cusbooneysiin iyo macluumaad ku saabsan diiwaangelintaada, iyo cusbooneysiinta shabakadeena?",
+			"Waxaan ogolahay inaan helo xaqiijinta iyo cusbooneysiinta iimayl ah ee ku saabsan booqashadayda kaydka cuntada.",
 		register_about_family: "Reerkaaga wax nooga sheeg",
 		family_count:
 			"Immisa xubnood oo qoys ah ayaa ku jira da 'kasta? (Ha ku darin naftaada)",
@@ -2469,12 +2469,12 @@ let localization = new LocalizedStrings({
 		phone_number: "Номер телефона (предпочтительно мобильный)",
 		no_phone: "Телефон недоступен",
 		phone_contact_you:
-			"Можно ли связываться с вами с обновлениями и информацией о вашей регистрации и обновлениями в нашей сети?",
+			"Я соглашаюсь получать SMS-подтверждения о моём посещении продовольственного банка. Могут применяться тарифы за сообщения и передачу данных. Отправьте STOP для отмены.",
 		no_email: "Электронная почта недоступна",
 		label_no_email_question: "Нет электронной почты?",
 		label_get_free_email: "Получите бесплатно от Google.",
 		email_contact_you:
-			"Можно ли отправлять вам по электронной почте обновления и информацию о вашей регистрации и обновлениях в нашей сети?",
+			"Я соглашаюсь получать подтверждения и обновления по электронной почте о моём посещении продовольственного банка.",
 		register_about_family: "Информация о вашей семье",
 		family_count:
 			"Сколько дополнительных членов семьи в каждой возрастной группе? (Не включайте себя)",
@@ -3279,12 +3279,12 @@ let localization = new LocalizedStrings({
 		phone_number: "Telefon Numarası (Mobil Tercihli)",
 		no_phone: "Telefon Yok",
 		phone_contact_you:
-			"Kaydınızla ilgili güncellemeler ve bilgiler ve ağımızdaki güncellemeler için sizinle iletişime geçebilir miyim?",
+			"Gıda bankası ziyaretim için SMS metin mesajı onayları almayı kabul ediyorum. Mesaj ve veri ücretleri uygulanabilir. Vazgeçmek için STOP yanıtlayın.",
 		no_email: "Kullanılabilir E-posta Yok",
 		label_no_email_question: "E-postanız yok mu?",
 		label_get_free_email: "Google'dan ücretsiz bir tane edinin.",
 		email_contact_you:
-			"Kaydınızla ilgili güncellemeler ve bilgiler ve ağımızdaki güncellemeler ile size e-posta gönderebilir miyim?",
+			"Gıda bankası ziyaretim hakkında e-posta onayları ve güncellemeler almayı kabul ediyorum.",
 		register_about_family: "Bize ailenden bahset",
 		family_count:
 			"Her yaş grubunda kaç aile üyesi daha var? (Kendinizi dahil etmeyin)",
@@ -4064,12 +4064,12 @@ let localization = new LocalizedStrings({
 		phone_number: "رقم الهاتف (يفضل الجوال)",
 		no_phone: "لا يوجد هاتف متاح",
 		phone_contact_you:
-			"هل من المقبول الاتصال بك للحصول على تحديثات ومعلومات حول تسجيلك وتحديثات لشبكتنا؟",
+			"أوافق على تلقي رسائل تأكيد نصية SMS لزيارتي لبنك الطعام. قد تُطبق رسوم الرسائل والبيانات. أرسل STOP لإلغاء الاشتراك.",
 		no_email: "لا يوجد بريد إلكتروني متاح",
 		label_no_email_question: "ليس لديك بريد إلكتروني؟",
 		label_get_free_email: "احصل على واحد مجاناً من Google.",
 		email_contact_you:
-			"هل من المقبول مراسلتك عبر البريد الإلكتروني بالتحديثات والمعلومات حول التسجيل والتحديثات الخاصة بشبكتنا؟",
+			"أوافق على تلقي تأكيدات وتحديثات عبر البريد الإلكتروني حول زيارتي لبنك الطعام.",
 		register_about_family: "أخبرنا عن عائلتك",
 		family_count:
 			"كم عدد أفراد الأسرة الإضافيين في كل فئة عمرية؟ (لا تشمل نفسك)",
@@ -4829,12 +4829,12 @@ let localization = new LocalizedStrings({
 		phone_number: "电话号码（首选移动电话）",
 		no_phone: "没有可用的电话",
 		phone_contact_you:
-			"是否可以与您联系以获取有关注册的更新和信息以及我们网络的更新",
+			"我同意接收有关食物银行访问的短信确认。可能会收取短信和数据费用。回复 STOP 取消订阅。",
 		no_email: "没有可用的电子邮件",
 		label_no_email_question: "没有电子邮件？",
 		label_get_free_email: "从Google免费获取一个。",
 		email_contact_you:
-			"可以通过电子邮件向您发送有关注册的更新和信息以及我们网络的更新吗",
+			"我同意接收有关食物银行访问的电子邮件确认和更新。",
 		register_about_family: "告诉我们你的家人",
 		family_count: "每个年龄段还有多少家庭成员？ （不要包括自己)",
 		seniors: "老年人",
@@ -5572,12 +5572,12 @@ let localization = new LocalizedStrings({
 		phone_number: "फ़ोन नंबर (मोबाइल पसंदीदा)",
 		no_phone: "कोई फोन उपलब्ध नहीं है",
 		phone_contact_you:
-			"क्या आपको अपने पंजीकरण के बारे में जानकारी और जानकारी और हमारे नेटवर्क के अपडेट से संपर्क करना ठीक है?",
+			"मैं अपनी खाद्य बैंक यात्रा के लिए SMS पाठ संदेश पुष्टिकरण प्राप्त करने के लिए सहमत हूँ। संदेश और डेटा शुल्क लागू हो सकते हैं। सदस्यता रद्द करने के लिए STOP उत्तर दें।",
 		no_email: "कोई ईमेल उपलब्ध नहीं है",
 		label_no_email_question: "ईमेल नहीं है?",
 		label_get_free_email: "Google से एक मुफ़्त प्राप्त करें।",
 		email_contact_you:
-			"क्या आपको अपने पंजीकरण के बारे में जानकारी और जानकारी और हमारे नेटवर्क के अपडेट के साथ ईमेल करना ठीक है?",
+			"मैं अपनी खाद्य बैंक यात्रा के बारे में ईमेल पुष्टिकरण और अपडेट प्राप्त करने के लिए सहमत हूँ।",
 		register_about_family: "अपने परिवार के बारे में हमें बताएं",
 		family_count:
 			"प्रत्येक आयु वर्ग में कितने अतिरिक्त परिवार के सदस्य हैं? (खुद को शामिल न करें)",
@@ -6357,12 +6357,12 @@ let localization = new LocalizedStrings({
 		phone_number: "फोन नम्बर (मोबाइल मनपर्दो)",
 		no_phone: "कुनै फोन उपलब्ध छैन",
 		phone_contact_you:
-			"के तपाइँसँग तपाइँको रेजिष्ट्रेसनको बारेमा अद्यावधिक र जानकारी, र हाम्रो नेटवर्कमा अद्यावधिक जानकारीका साथ सम्पर्क गर्न ठीक छ?",
+			"म मेरो खाद्य बैंक भ्रमणको लागि SMS पाठ सन्देश पुष्टिकरणहरू प्राप्त गर्न सहमत छु। सन्देश र डाटा शुल्क लागू हुन सक्छ। सदस्यता रद्द गर्न STOP जवाफ दिनुहोस्।",
 		no_email: "कुनै ईमेल उपलब्ध छैन",
 		label_no_email_question: "इमेल छैन?",
 		label_get_free_email: "Google बाट एउटा निःशुल्क प्राप्त गर्नुहोस्।",
 		email_contact_you:
-			"के तपाइँलाई तपाइँको पंजीकरणको बारेमा अद्यावधिक र जानकारी, र हाम्रो नेटवर्कमा अद्यावधिकको साथ ईमेल गर्न ठीक छ?",
+			"म मेरो खाद्य बैंक भ्रमणको बारेमा ईमेल पुष्टिकरण र अपडेटहरू प्राप्त गर्न सहमत छु।",
 		register_about_family: "तपाईंको परिवारको बारेमा हामीलाई भन्नुहोस्",
 		family_count:
 			"प्रत्येक उमेर समूहमा कति अतिरिक्त परिवार सदस्यहरू छन्? (आफूलाई समावेश नगर्नुहोस्)",


### PR DESCRIPTION
FTW-748: Updated phone input checkbox consent label
## Summary
- Updated phone input checkbox consent label and localization
- Version bump to 2.0.8
- Cherry-picked from FTW-748 onto the last prod state (MemberCountFix) to exclude unreleased beta/dev changes

## Changes
- `.babelrc` — updated config
- `LocalizationComponent.js` — updated consent label localizations
- `package.json` — version bump to 2.0.8
- Updated related tests

## Context
Beta was reset to the last production deploy (`8f0e98a` — MemberCountFix) to ensure this PR does not include any unreleased dev/beta work.