### PR TITLE
Fixed registration issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.12.0",
         "@hookform/resolvers": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "homepage": "https://freshtrak.com",
   "dependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,22 @@ const App = () => {
 		// Clear expired data from both localStorage and sessionStorage on app initialization
 		StorageService.clearExpiredData("local");
 		StorageService.clearExpiredData("session");
+
+		// Cross-session guest data guard.
+		//
+		// sessionStorage is wiped automatically when a tab or browser is closed, but
+		// localStorage is not.  If guest data is present in localStorage but the
+		// session marker is absent from sessionStorage, the data belongs to a prior
+		// browser session (e.g. the user closed the tab before dismissing the
+		// "Create Account" popup).  Clear it now so it cannot be picked up as an
+		// active guest session by a different person using the same browser.
+		if (StorageService.getGuestUser() && !StorageService.hasGuestSessionMarker()) {
+			StorageService.removeItem("freshtrak_user_guest");
+			StorageService.removeItem("userProfile"); // legacy key
+			StorageService.removeItem("guestId");
+			StorageService.removeItem("guestType");
+			StorageService.clearUserToken();
+		}
 	}, []);
 
 	// Page visibility handling - clear expired data when page becomes visible

--- a/src/Modules/Authentication/AuthContext.tsx
+++ b/src/Modules/Authentication/AuthContext.tsx
@@ -275,13 +275,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 				if (storedUserName && storedUserName.trim() !== "") {
 					userName = storedUserName;
 				} else {
-					// Fallback to pending user data (for unconfirmed users)
+					// Fallback to pending user data (for unconfirmed users completing sign-in).
+					// Guard with an email match: a stale pendingUser left behind by a different
+					// user's incomplete sign-up must not overwrite the name of the current user.
 					const pendingUser = StorageService.getItem<{
 						name?: string;
+						email?: string;
 						[key: string]: any;
 					}>("pendingUser");
 					if (pendingUser?.name && pendingUser.name.trim() !== "") {
-						userName = pendingUser.name;
+						if (!pendingUser.email || pendingUser.email === email) {
+							userName = pendingUser.name;
+						} else {
+							// Stale pendingUser belongs to a different account – discard it
+							StorageService.removeItem("pendingUser");
+						}
 					}
 				}
 

--- a/src/Modules/Authentication/LoginPage.tsx
+++ b/src/Modules/Authentication/LoginPage.tsx
@@ -67,14 +67,17 @@ const LoginPage: React.FC = () => {
 			// Clear Cognito authentication data when logging in as guest
 			StorageService.clearAuthData("cognito");
 
-			const resp = await axios.post(GUEST_USER);
-			const userProfile = resp.data;
-			// Use StorageService to store guest user profile (uses 'freshtrak_user_guest' key)
-			StorageService.setItem("freshtrak_user_guest", userProfile);
-			// Also store token if available
-			if (userProfile.token) {
-				StorageService.setUserToken(userProfile.token);
-			}
+		const resp = await axios.post(GUEST_USER);
+		const userProfile = resp.data;
+		// Use StorageService to store guest user profile (uses 'freshtrak_user_guest' key)
+		StorageService.setItem("freshtrak_user_guest", userProfile);
+		// Also store token if available
+		if (userProfile.token) {
+			StorageService.setUserToken(userProfile.token);
+		}
+		// Mark this guest session as belonging to the current browser session so
+		// App.js can detect and discard stale guest data after a tab/browser close.
+		StorageService.setGuestSessionMarker();
 
 			// Track guest login event with Google Tag Manager
 			const gtmEvent: GTMEvent = {

--- a/src/Modules/Registration/RegistrationConfirmComponent.tsx
+++ b/src/Modules/Registration/RegistrationConfirmComponent.tsx
@@ -57,6 +57,28 @@ const RegistrationConfirmComponent: React.FC<RegistrationConfirmProps> = (
 		useState<boolean>(false);
 	const [showRegisterAnotherDialog, setShowRegisterAnotherDialog] =
 		useState<boolean>(false);
+
+	/**
+	 * Called by the Dialog's own close mechanism (X button, Escape key, outside click).
+	 * When the user dismisses the popup without creating an account, all guest session
+	 * data must be cleared so that a subsequent sign-up by a different person in the
+	 * same browser session cannot accidentally inherit this guest's household via the
+	 * guest-upgrade flow.
+	 *
+	 * NOTE: when the "Create Account" button is clicked it calls setShowGuestSigninModal
+	 * directly, which bypasses onOpenChange entirely, so this handler is NOT invoked in
+	 * that case – the guest token is intentionally preserved for the upgrade flow.
+	 */
+	const handleGuestModalOpenChange = (open: boolean): void => {
+		if (!open) {
+			StorageService.removeItem("freshtrak_user_guest");
+			StorageService.removeItem("userProfile"); // legacy key
+			StorageService.removeItem("guestId");
+			StorageService.removeItem("guestType");
+			StorageService.clearUserToken();
+		}
+		setShowGuestSigninModal(open);
+	};
 	const eventDateId = StorageService.getRegisteredEventDateID();
 
 	const isLoggedIn = StorageService.getItem<string>("isLoggedIn");
@@ -555,11 +577,11 @@ const RegistrationConfirmComponent: React.FC<RegistrationConfirmProps> = (
 				</div>
 			)}
 
-			{/* Guest Sign-in Modal */}
-			<Dialog
-				open={showGuestSigninModal}
-				onOpenChange={setShowGuestSigninModal}
-			>
+		{/* Guest Sign-in Modal */}
+		<Dialog
+			open={showGuestSigninModal}
+			onOpenChange={handleGuestModalOpenChange}
+		>
 				<DialogContent className="sm:max-w-md bg-white border border-gray-200 text-gray-900">
 					<DialogHeader>
 						<DialogTitle className="text-center text-gray-900">

--- a/src/Modules/Registration/RegistrationEventDetailsContainer.tsx
+++ b/src/Modules/Registration/RegistrationEventDetailsContainer.tsx
@@ -119,11 +119,14 @@ const RegistrationEventDetailsContainer: React.FC<
 			// Clear Cognito authentication data when logging in as guest
 			StorageService.clearAuthData("cognito");
 
-			// Get guest authentication
-			const resp = await axios.post(GUEST_USER);
-			const userProfile = resp.data;
-			// Use StorageService to store guest user profile
-			StorageService.setItem("freshtrak_user_guest", userProfile);
+		// Get guest authentication
+		const resp = await axios.post(GUEST_USER);
+		const userProfile = resp.data;
+		// Use StorageService to store guest user profile
+		StorageService.setItem("freshtrak_user_guest", userProfile);
+		// Mark this guest session as belonging to the current browser session so
+		// App.js can detect and discard stale guest data after a tab/browser close.
+		StorageService.setGuestSessionMarker();
 
 			setLoading(false);
 			setshowAuthenticationModal(false);

--- a/src/Utils/StorageService.ts
+++ b/src/Utils/StorageService.ts
@@ -601,6 +601,40 @@ export class StorageService {
     // Session Management Methods
     // ============================================================================
 
+    // ============================================================================
+    // Guest Session Marker
+    //
+    // sessionStorage is automatically wiped when a tab or browser window is closed.
+    // localStorage is not.  We use a short-lived sessionStorage flag to track
+    // whether the current browser session created the guest profile that lives in
+    // localStorage.  On app startup we compare the two: if guest data exists in
+    // localStorage but the session marker is absent, the data belongs to a prior
+    // session and must be cleared before it can contaminate a new user's flow.
+    // ============================================================================
+
+    /**
+     * Write the guest session marker to sessionStorage.
+     * Must be called immediately after a new guest profile is created.
+     */
+    static setGuestSessionMarker(): void {
+        this.setItem('freshtrak_guest_session_active', true, 'session');
+    }
+
+    /**
+     * Returns true if the guest session marker exists in sessionStorage,
+     * meaning the guest profile in localStorage was created in this browser session.
+     */
+    static hasGuestSessionMarker(): boolean {
+        return this.getItem<boolean>('freshtrak_guest_session_active', 'session') === true;
+    }
+
+    /**
+     * Remove the guest session marker from sessionStorage.
+     */
+    static clearGuestSessionMarker(): void {
+        this.removeItem('freshtrak_guest_session_active', 'session');
+    }
+
     /**
      * Clear authentication data based on user type
      * @param userType - 'cognito' or 'guest'
@@ -613,6 +647,7 @@ export class StorageService {
         } else {
             this.removeItem('freshtrak_user_guest');
             this.removeItem('freshtrak_user_token');
+            this.clearGuestSessionMarker();
         }
 
         // Clear common auth data

--- a/src/Utils/UserRecordHelper.ts
+++ b/src/Utils/UserRecordHelper.ts
@@ -258,7 +258,17 @@ export const resolveUserNameWithFallback = async (
 		email?: string;
 	}>("pendingUser");
 
-	let userName = pendingUser?.name || authUser?.name;
+	// Only trust pendingUser.name when its email matches the confirming user's email.
+	// A stale pendingUser from a different user's incomplete sign-up must not
+	// contaminate the name of the user who is currently confirming.
+	const confirmedEmail = pendingEmail || authUser?.email;
+	const pendingNameIsForThisUser =
+		pendingUser?.name &&
+		(!pendingUser.email ||
+			!confirmedEmail ||
+			pendingUser.email === confirmedEmail);
+
+	let userName = (pendingNameIsForThisUser ? pendingUser?.name : undefined) || authUser?.name;
 	let userEmail = pendingEmail || pendingUser?.email || authUser?.email;
 
 	// If name not found in localStorage or context, try fetching from Cognito attributes


### PR DESCRIPTION
What happened:
Guest user registers -> lands on confirmation page -> closes popup that offers account setup -> goes to sign in page and signs up as a different user. Result: app was creating a new user using guest user info. 
 
Guest user's stale storage was not clearing
 