### PR TITLE
fix: updated date handling, fixed gender bug in household setup, fixed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium firefox webkit
 
+      # Pre-create the output directory so Playwright's storageState() has a
+      # parent directory to write into on all runner environments.
+      - name: Create auth state directory
+        run: mkdir -p e2e/.auth
+
       - name: Authenticate once
         run: npx playwright test --project=setup
         env:
@@ -122,8 +127,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: e2e-auth-state
-          path: e2e/.auth/
+          # Upload by explicit file path rather than directory to avoid hidden-
+          # directory glob quirks. Fails the job immediately if the file wasn't
+          # produced, so downstream shards get a clear dependency failure rather
+          # than an opaque "artifact not found" error.
+          path: e2e/.auth/user.json
           retention-days: 1
+          if-no-files-found: error
 
   # e2e runs as a 3-way shard matrix so each runner handles ~1/3 of the tests
   # across all three browsers in parallel, cutting wall-clock time by ~60%.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - run: npm ci
       - run: npm run test:ci
 
-  e2e:
+  # Build the production bundle once and share it with all e2e shards.
+  # This removes the per-shard build cost (~60-90s) from the e2e critical path.
+  build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
-    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -41,8 +41,67 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps chromium firefox webkit
-      - run: npx playwright test
+        env:
+          REACT_APP_REGISTRATION_API: ${{ vars.REACT_APP_REGISTRATION_API }}
+          REACT_APP_PANTRY_FINDER_API: ${{ vars.REACT_APP_PANTRY_FINDER_API }}
+          REACT_APP_AWS_REGION: ${{ vars.REACT_APP_AWS_REGION }}
+          REACT_APP_USER_POOL_ID: ${{ vars.REACT_APP_USER_POOL_ID }}
+          REACT_APP_USER_POOL_CLIENT_ID: ${{ vars.REACT_APP_USER_POOL_CLIENT_ID }}
+          REACT_APP_CLIENT_URL: ${{ vars.REACT_APP_CLIENT_URL }}
+          REACT_APP_FRESHTRAK_PARTNERS_URL: ${{ vars.REACT_APP_FRESHTRAK_PARTNERS_URL }}
+          REACT_APP_GTM_ID: ${{ vars.REACT_APP_GTM_ID }}
+          REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
+      - uses: actions/upload-artifact@v6
+        with:
+          name: app-build
+          # Vite outputs to dist/ by default (no custom outDir in vite.config.mts)
+          path: dist/
+          retention-days: 1
+
+  # Run auth.setup.ts exactly once to produce the Cognito session state.
+  # Uploading it as an artifact lets all three shards reuse it without
+  # triggering additional sign-ins, avoiding Cognito rate-limit collisions.
+  # This job also warms the Playwright browser cache so shards start faster.
+  e2e-setup:
+    runs-on: ubuntu-latest
+    needs: build
+    # Worst-case on a cold browser cache: npm ci (~2 min) + playwright install
+    # for three browsers (~4 min) + up to three 180s Cognito login attempts
+    # (~9 min) = ~15 min. 20 minutes gives a comfortable buffer.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: app-build
+          path: dist/
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium firefox webkit
+
+      - name: Authenticate once
+        run: npx playwright test --project=setup
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:5000
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
@@ -58,8 +117,124 @@ jobs:
           REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
           REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
           REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
+
+      - name: Upload auth state
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-auth-state
+          path: e2e/.auth/
+          retention-days: 1
+
+  # e2e runs as a 3-way shard matrix so each runner handles ~1/3 of the tests
+  # across all three browsers in parallel, cutting wall-clock time by ~60%.
+  # Shards depend on e2e-setup so the Cognito auth state and browser cache are
+  # ready before any shard starts — no redundant sign-ins, no cache misses.
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [lint, test, e2e-setup]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: app-build
+          # Restore into dist/ to match Vite's output path expected by vite preview
+          path: dist/
+
+      - name: Download auth state
+        uses: actions/download-artifact@v6
+        with:
+          name: e2e-auth-state
+          # Restores user.json to e2e/.auth/ — auth.setup.ts detects the file
+          # and skips re-authentication, preventing concurrent Cognito sign-ins.
+          path: e2e/.auth/
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium firefox webkit
+
+      - name: Run Playwright tests (shard ${{ matrix.shard }})
+        run: npx playwright test --shard=${{ matrix.shard }}
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:5000
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          REACT_APP_REGISTRATION_API: ${{ vars.REACT_APP_REGISTRATION_API }}
+          REACT_APP_PANTRY_FINDER_API: ${{ vars.REACT_APP_PANTRY_FINDER_API }}
+          REACT_APP_AWS_REGION: ${{ vars.REACT_APP_AWS_REGION }}
+          REACT_APP_USER_POOL_ID: ${{ vars.REACT_APP_USER_POOL_ID }}
+          REACT_APP_USER_POOL_CLIENT_ID: ${{ vars.REACT_APP_USER_POOL_CLIENT_ID }}
+          REACT_APP_CLIENT_URL: ${{ vars.REACT_APP_CLIENT_URL }}
+          REACT_APP_FRESHTRAK_PARTNERS_URL: ${{ vars.REACT_APP_FRESHTRAK_PARTNERS_URL }}
+          REACT_APP_GTM_ID: ${{ vars.REACT_APP_GTM_ID }}
+          REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v6
+        # always() ensures upload runs whether tests passed, failed, or the
+        # shard was cancelled mid-run — partial results are still mergeable.
+        # if-no-files-found: ignore handles the edge case where Playwright
+        # exited before writing any output (e.g. webServer failed to start).
+        if: always()
+        with:
+          name: blob-report-${{ strategy.job-index }}
+          path: blob-report/
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Merge the per-shard blob reports into a single HTML report once all
+  # shards finish (whether they passed or failed).
+  e2e-report:
+    runs-on: ubuntu-latest
+    needs: e2e
+    # Run when shards finished (success or failure) — both states mean blob
+    # reports were uploaded and can be merged. Explicitly exclude 'skipped'
+    # (e.g. e2e-setup failed so e2e never ran) and 'cancelled' (no artifacts
+    # uploaded), which always() would incorrectly include.
+    if: ${{ needs.e2e.result == 'success' || needs.e2e.result == 'failure' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v6
+        with:
+          pattern: blob-report-*
+          merge-multiple: true
+          path: all-blob-reports/
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
       - uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -7,14 +7,24 @@ const MAX_LOGIN_ATTEMPTS = 3;
 
 /**
  * Validates that the Playwright storage-state file at the given path contains
- * usable authentication data.  Three checks must all pass:
+ * usable authentication data.  All checks must pass:
  *
  *   1. The file exists and parses as valid JSON.
  *   2. At least one origin with localStorage entries is present (an auth state
  *      written before Cognito login completes would be empty).
- *   3. No JWT found in localStorage has an expired `exp` claim — Cognito issues
- *      short-lived (~1 h) idTokens, so a stale artifact that predates the next
- *      CI run must not silently pass.
+ *   3. At least one JWT is found in localStorage AND at least one of those
+ *      JWTs has a non-expired `exp` claim.
+ *
+ * The JWT check deliberately uses an "any valid" rather than "none expired"
+ * strategy for two reasons:
+ *   - Cognito stores both an idToken and an accessToken; finding either one
+ *     valid is sufficient for a usable session.
+ *   - Rejecting on the first expired entry would fail spuriously when
+ *     localStorage also holds another, still-valid token for the same session.
+ *
+ * Requiring at least one JWT (rather than just any localStorage items) prevents
+ * a corrupt or pre-login artifact — which would have storage entries but no
+ * Cognito tokens — from being mistakenly accepted.
  */
 function hasValidStorageState(filePath: string): boolean {
   if (!existsSync(filePath)) return false;
@@ -32,25 +42,34 @@ function hasValidStorageState(filePath: string): boolean {
     const allItems: LocalStorageItem[] = origins.flatMap((o) => o.localStorage ?? []);
     if (allItems.length === 0) return false;
 
-    // Reject if any decodable JWT is expired.
+    // Scan for JWT-shaped values (header.payload.signature where both header
+    // and payload are base64url-encoded JSON objects starting with "{").
+    // We require finding at least one valid (non-expired) JWT:
+    //   • No JWT found          → probably a pre-login or corrupt artifact → false
+    //   • All found JWTs expired → stale artifact → false
+    //   • At least one valid JWT → usable session → true (early return)
     const nowSecs = Math.floor(Date.now() / 1000);
+
     for (const { value } of allItems) {
-      // A JWT has the form: <base64url>.<base64url>.<base64url> where the first
-      // two segments decode to JSON objects that begin with "{".
       if (!/^eyJ[\w-]+\.eyJ[\w-]+\.[\w-]+$/.test(value)) continue;
       try {
         const payload = JSON.parse(
           Buffer.from(value.split('.')[1], 'base64url').toString('utf-8'),
         ) as { exp?: number };
-        if (typeof payload.exp === 'number' && payload.exp <= nowSecs) {
-          return false;
+        // A token with no `exp` (uncommon but valid) is treated as non-expiring.
+        if (typeof payload.exp !== 'number' || payload.exp > nowSecs) {
+          return true; // At least one valid JWT — session is usable.
         }
       } catch {
-        // Unparseable JWT segment — skip; other tokens govern the decision.
+        // Unparseable payload — skip; keep looking.
       }
     }
 
-    return true;
+    // Reaching here means either:
+    //   (a) no JWT-shaped values were present (pre-login or corrupt artifact), or
+    //   (b) every decoded JWT was expired.
+    // Both cases indicate an unusable auth state.
+    return false;
   } catch {
     return false;
   }

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import { test as setup, expect } from '@playwright/test';
 import { SEL } from '../helpers/selectors';
 import { TEST_USER, AUTH_STATE_PATH, ROUTES } from '../helpers/test-data';
@@ -5,6 +6,16 @@ import { TEST_USER, AUTH_STATE_PATH, ROUTES } from '../helpers/test-data';
 const MAX_LOGIN_ATTEMPTS = 3;
 
 setup('authenticate test user', async ({ page }) => {
+  // In CI the auth state is produced once by the dedicated e2e-setup job and
+  // downloaded as an artifact before each shard starts. Skip re-authentication
+  // to avoid concurrent Cognito sign-ins across shards hitting rate limits.
+  //
+  // The CI guard is intentional: locally we always perform a fresh login so
+  // a leftover file with expired tokens never silently breaks the test run.
+  if (process.env.CI && existsSync(AUTH_STATE_PATH)) {
+    return;
+  }
+
   setup.setTimeout(180_000);
 
   for (let attempt = 1; attempt <= MAX_LOGIN_ATTEMPTS; attempt++) {

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -1,9 +1,60 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { test as setup, expect } from '@playwright/test';
 import { SEL } from '../helpers/selectors';
 import { TEST_USER, AUTH_STATE_PATH, ROUTES } from '../helpers/test-data';
 
 const MAX_LOGIN_ATTEMPTS = 3;
+
+/**
+ * Validates that the Playwright storage-state file at the given path contains
+ * usable authentication data.  Three checks must all pass:
+ *
+ *   1. The file exists and parses as valid JSON.
+ *   2. At least one origin with localStorage entries is present (an auth state
+ *      written before Cognito login completes would be empty).
+ *   3. No JWT found in localStorage has an expired `exp` claim — Cognito issues
+ *      short-lived (~1 h) idTokens, so a stale artifact that predates the next
+ *      CI run must not silently pass.
+ */
+function hasValidStorageState(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+
+  try {
+    type LocalStorageItem = { name: string; value: string };
+    type StorageOrigin = { origin: string; localStorage?: LocalStorageItem[] };
+    const state = JSON.parse(readFileSync(filePath, 'utf-8')) as {
+      cookies?: unknown[];
+      origins?: StorageOrigin[];
+    };
+
+    // Require at least one origin with localStorage data.
+    const origins = state.origins ?? [];
+    const allItems: LocalStorageItem[] = origins.flatMap((o) => o.localStorage ?? []);
+    if (allItems.length === 0) return false;
+
+    // Reject if any decodable JWT is expired.
+    const nowSecs = Math.floor(Date.now() / 1000);
+    for (const { value } of allItems) {
+      // A JWT has the form: <base64url>.<base64url>.<base64url> where the first
+      // two segments decode to JSON objects that begin with "{".
+      if (!/^eyJ[\w-]+\.eyJ[\w-]+\.[\w-]+$/.test(value)) continue;
+      try {
+        const payload = JSON.parse(
+          Buffer.from(value.split('.')[1], 'base64url').toString('utf-8'),
+        ) as { exp?: number };
+        if (typeof payload.exp === 'number' && payload.exp <= nowSecs) {
+          return false;
+        }
+      } catch {
+        // Unparseable JWT segment — skip; other tokens govern the decision.
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 setup('authenticate test user', async ({ page }) => {
   // In CI the auth state is produced once by the dedicated e2e-setup job and
@@ -12,7 +63,7 @@ setup('authenticate test user', async ({ page }) => {
   //
   // The CI guard is intentional: locally we always perform a fresh login so
   // a leftover file with expired tokens never silently breaks the test run.
-  if (process.env.CI && existsSync(AUTH_STATE_PATH)) {
+  if (process.env.CI && hasValidStorageState(AUTH_STATE_PATH)) {
     return;
   }
 

--- a/e2e/tests/registration-flow.spec.ts
+++ b/e2e/tests/registration-flow.spec.ts
@@ -61,7 +61,12 @@ async function openTimeslotDialog(
 
   // Wait for the event details page to fully load
   await expect(page).toHaveURL(/\/register\/event\/[^/]+/, { timeout: 10_000 });
-  await page.locator('.back-button').waitFor({ state: 'visible', timeout: 20_000 });
+  // Allow network activity to settle before checking for DOM elements.
+  // Firefox and Webkit are slower to paint React components after navigation.
+  await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {
+    // networkidle may not fire on pages with persistent connections; ignore.
+  });
+  await page.locator('.back-button').waitFor({ state: 'visible', timeout: 30_000 });
 
   // Click Register Now — authenticated users navigate directly to the registration form
   await page.getByTestId(SEL.registerNowButton).click();
@@ -712,6 +717,10 @@ test.describe('Registration Flow – Step 3: Your Family Details', () => {
   test('Previous and Register buttons are visible on Step 3', async ({
     authenticatedPage: page,
   }) => {
+    // Navigation chain is long (search → event → timeslot → modal → step1 → step2 → step3);
+    // triple the default timeout to accommodate Firefox/Webkit rendering latency.
+    test.slow();
+
     const result = await navigateToFamilyStep(page);
     if (!result.ready) {
       test.skip();
@@ -723,6 +732,10 @@ test.describe('Registration Flow – Step 3: Your Family Details', () => {
   });
 
   test('clicking Previous on Step 3 returns to Step 2', async ({ authenticatedPage: page }) => {
+    // Navigation chain is long (search → event → timeslot → modal → step1 → step2 → step3);
+    // triple the default timeout to accommodate Firefox/Webkit rendering latency.
+    test.slow();
+
     const result = await navigateToFamilyStep(page);
     if (!result.ready) {
       test.skip();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "3.2.2",
+  "version": "3.2.2-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "3.2.2",
+      "version": "3.2.2-0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.12.0",
         "@hookform/resolvers": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.2.2-0",
+  "version": "3.2.3",
   "private": true,
   "homepage": "https://freshtrak.com",
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Run one worker per browser project in CI (chromium, firefox, webkit).
+  // Locally Playwright auto-selects based on CPU count.
+  workers: process.env.CI ? 3 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
 
   expect: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,10 +12,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  // Run one worker per browser project in CI (chromium, firefox, webkit).
-  // Locally Playwright auto-selects based on CPU count.
-  workers: process.env.CI ? 3 : undefined,
-  reporter: [['html', { open: 'never' }], ['list']],
+  // 4 workers per shard. ubuntu-latest has 4 vCPUs and e2e tests are largely
+  // I/O-bound (network, navigation waits), so 4 concurrent workers saturates
+  // the runner without CPU contention.
+  workers: process.env.CI ? 4 : undefined,
+  // In CI emit a blob report so the merge job can combine shards into one
+  // HTML report. Locally keep the interactive HTML report.
+  reporter: process.env.CI ? [['blob'], ['list']] : [['html', { open: 'never' }], ['list']],
 
   expect: {
     timeout: 10_000,

--- a/src/Modules/Account/components/AccountInfoSection.tsx
+++ b/src/Modules/Account/components/AccountInfoSection.tsx
@@ -81,15 +81,21 @@ const AccountInfoSection: React.FC<AccountInfoSectionProps> = ({ householdData }
 
     const dob = headOfHousehold.date_of_birth;
 
-    // Format date of birth for display
-    const formattedDOB =
-      dob && dob !== '1900-01-01'
-        ? new Date(dob).toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric',
-          })
-        : null;
+    // Format date of birth for display.
+    // Manually parse YYYY-MM-DD components to avoid new Date("YYYY-MM-DD")
+    // treating the string as UTC midnight, which shifts the displayed date
+    // back by one day in negative-offset timezones (e.g. UTC-4).
+    const formattedDOB = (() => {
+      if (!dob || dob === '1900-01-01') return null;
+      const parts = dob.split('-').map(Number);
+      if (parts.length !== 3 || parts.some(isNaN)) return null;
+      const [y, m, d] = parts;
+      return new Date(y, m - 1, d).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    })();
 
     // Convert gender_id to readable label (handle both string and number)
     const getGenderLabel = (genderId: number | string | null): string | null => {

--- a/src/Modules/Authentication/__test__/CaseManagerLoginPage.test.tsx
+++ b/src/Modules/Authentication/__test__/CaseManagerLoginPage.test.tsx
@@ -1,12 +1,15 @@
-import React from "react";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+// Import after all jest.mock calls
+import CaseManagerLoginPage from '../CaseManagerLoginPage';
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-  const actual = jest.requireActual("react-router-dom");
-  const React = jest.requireActual("react");
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  const React = jest.requireActual('react');
   const withFutureFlags = (RouterComponent: React.ComponentType<any>) => {
     const WrappedRouter = ({ future, ...props }: any) =>
       React.createElement(RouterComponent, {
@@ -30,7 +33,7 @@ jest.mock("react-router-dom", () => {
 
 const mockSignIn = jest.fn();
 const mockSignOut = jest.fn();
-jest.mock("../AuthContext", () => ({
+jest.mock('../AuthContext', () => ({
   useAuth: () => ({
     signIn: mockSignIn,
     signOut: mockSignOut,
@@ -39,18 +42,18 @@ jest.mock("../AuthContext", () => ({
 }));
 
 const mockFetchAuthSession = jest.fn();
-jest.mock("aws-amplify/auth", () => ({
+jest.mock('aws-amplify/auth', () => ({
   fetchAuthSession: (...args: any[]) => mockFetchAuthSession(...args),
 }));
 
-jest.mock("@hookform/resolvers/zod", () => ({
+jest.mock('@hookform/resolvers/zod', () => ({
   zodResolver: () => async (values: any) => ({
     values,
     errors: {},
   }),
 }));
 
-jest.mock("zod", () => {
+jest.mock('zod', () => {
   const stringField = () => ({
     email: () => stringField(),
     min: () => stringField(),
@@ -63,35 +66,32 @@ jest.mock("zod", () => {
   };
 });
 
-jest.mock("../../Localization/LocalizationComponent", () => ({
+jest.mock('../../Localization/LocalizationComponent', () => ({
   __esModule: true,
   default: {
-    cm_login_title: "Case Manager Sign In",
-    cm_login_subtitle: "Sign in with your case manager credentials",
-    cm_login_email_label: "Email",
-    cm_login_password_label: "Password",
-    cm_login_button: "Sign In",
-    cm_login_error_generic: "Something went wrong. Please try again.",
-    cm_login_unauthorized: "You are not authorized as a case manager.",
-    cm_login_link: "Are you a Case Manager?",
-    error_please_enter_valid_email: "Please enter a valid email",
-    error_password_required: "Password is required",
-    button_back: "Back",
-    button_back_to_home: "Back to Home",
+    cm_login_title: 'Case Manager Sign In',
+    cm_login_subtitle: 'Sign in with your case manager credentials',
+    cm_login_email_label: 'Email',
+    cm_login_password_label: 'Password',
+    cm_login_button: 'Sign In',
+    cm_login_error_generic: 'Something went wrong. Please try again.',
+    cm_login_unauthorized: 'You are not authorized as a case manager.',
+    cm_login_link: 'Are you a Case Manager?',
+    error_please_enter_valid_email: 'Please enter a valid email',
+    error_password_required: 'Password is required',
+    button_back: 'Back',
+    button_back_to_home: 'Back to Home',
   },
 }));
 
-jest.mock("../../../Utils/StorageService", () => ({
+jest.mock('../../../Utils/StorageService', () => ({
   StorageService: {
     setUserRole: jest.fn(),
   },
 }));
 
-// Import after all jest.mock calls
-import CaseManagerLoginPage from "../CaseManagerLoginPage";
-
 function buildJwt(payload: Record<string, any>): string {
-  const header = btoa(JSON.stringify({ alg: "HS256" }));
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
   const body = btoa(JSON.stringify(payload));
   return `${header}.${body}.signature`;
 }
@@ -103,148 +103,136 @@ const renderPage = () =>
     </MemoryRouter>,
   );
 
-describe("CaseManagerLoginPage", () => {
+describe('CaseManagerLoginPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe("Rendering", () => {
-    it("renders the login form with title and subtitle", () => {
+  describe('Rendering', () => {
+    it('renders the login form with title and subtitle', () => {
       renderPage();
-      expect(screen.getByText("Case Manager Sign In")).toBeInTheDocument();
-      expect(
-        screen.getByText("Sign in with your case manager credentials"),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Case Manager Sign In')).toBeInTheDocument();
+      expect(screen.getByText('Sign in with your case manager credentials')).toBeInTheDocument();
     });
 
-    it("renders email and password fields", () => {
+    it('renders email and password fields', () => {
       renderPage();
-      expect(screen.getByLabelText("Email")).toBeInTheDocument();
-      expect(screen.getByLabelText("Password")).toBeInTheDocument();
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+      expect(screen.getByLabelText('Password')).toBeInTheDocument();
     });
 
-    it("renders the sign in button", () => {
+    it('renders the sign in button', () => {
       renderPage();
-      expect(
-        screen.getByRole("button", { name: "Sign In" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
     });
 
-    it("renders back and home navigation buttons", () => {
+    it('renders back and home navigation buttons', () => {
       renderPage();
       expect(screen.getByText(/Back$/)).toBeInTheDocument();
-      expect(screen.getByText("Back to Home")).toBeInTheDocument();
+      expect(screen.getByText('Back to Home')).toBeInTheDocument();
     });
   });
 
-  describe("Form interaction", () => {
-    it("allows typing into email and password fields", async () => {
+  describe('Form interaction', () => {
+    it('allows typing into email and password fields', async () => {
       renderPage();
-      const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
-      const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
+      const emailInput = screen.getByLabelText('Email') as HTMLInputElement;
+      const passwordInput = screen.getByLabelText('Password') as HTMLInputElement;
 
-      await userEvent.type(emailInput, "test@example.com");
-      await userEvent.type(passwordInput, "secret");
+      await userEvent.type(emailInput, 'test@example.com');
+      await userEvent.type(passwordInput, 'secret');
 
-      expect(emailInput.value).toBe("test@example.com");
-      expect(passwordInput.value).toBe("secret");
+      expect(emailInput.value).toBe('test@example.com');
+      expect(passwordInput.value).toBe('secret');
     });
 
-    it("disables submit button while submitting", async () => {
+    it('disables submit button while submitting', async () => {
       mockSignIn.mockReturnValue(new Promise(() => {}));
       renderPage();
 
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "pass");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'pass');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        const button = screen.getByRole("button", { name: /Sign In/i });
+        const button = screen.getByRole('button', { name: /Sign In/i });
         expect(button).toBeDisabled();
       });
     });
   });
 
-  describe("Successful login", () => {
-    it("navigates to home on successful case manager login", async () => {
-      const token = buildJwt({ "cognito:groups": ["case_managers"] });
+  describe('Successful login', () => {
+    it('navigates to home on successful case manager login', async () => {
+      const token = buildJwt({ 'cognito:groups': ['case_managers'] });
       mockSignIn.mockResolvedValue(undefined);
       mockFetchAuthSession.mockResolvedValue({
         tokens: { idToken: { toString: () => token } },
       });
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "password123");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'password123');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith("/");
+        expect(mockNavigate).toHaveBeenCalledWith('/');
       });
     });
 
-    it("sets case manager role in storage on success", async () => {
-      const { StorageService } = require("../../../Utils/StorageService");
-      const token = buildJwt({ "cognito:groups": ["case_managers"] });
+    it('sets case manager role in storage on success', async () => {
+      const { StorageService } = require('../../../Utils/StorageService');
+      const token = buildJwt({ 'cognito:groups': ['case_managers'] });
       mockSignIn.mockResolvedValue(undefined);
       mockFetchAuthSession.mockResolvedValue({
         tokens: { idToken: { toString: () => token } },
       });
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "password123");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'password123');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(StorageService.setUserRole).toHaveBeenCalledWith(
-          "case_manager",
-        );
+        expect(StorageService.setUserRole).toHaveBeenCalledWith('case_manager');
       });
-    });
+    }, 15000);
   });
 
-  describe("Authorization failures", () => {
-    it("shows unauthorized error when user not in case_managers group", async () => {
-      const token = buildJwt({ "cognito:groups": ["regular_users"] });
+  describe('Authorization failures', () => {
+    it('shows unauthorized error when user not in case_managers group', async () => {
+      const token = buildJwt({ 'cognito:groups': ['regular_users'] });
       mockSignIn.mockResolvedValue(undefined);
       mockFetchAuthSession.mockResolvedValue({
         tokens: { idToken: { toString: () => token } },
       });
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "user@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "password123");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'user@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'password123');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText(
-            "You are not authorized as a case manager.",
-          ),
-        ).toBeInTheDocument();
+        expect(screen.getByText('You are not authorized as a case manager.')).toBeInTheDocument();
       });
       expect(mockSignOut).toHaveBeenCalled();
     });
 
-    it("shows generic error when no access token is returned", async () => {
+    it('shows generic error when no access token is returned', async () => {
       mockSignIn.mockResolvedValue(undefined);
       mockFetchAuthSession.mockResolvedValue({ tokens: {} });
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "user@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "password123");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'user@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'password123');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Something went wrong. Please try again."),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
       });
       expect(mockSignOut).toHaveBeenCalled();
     });
 
-    it("shows error when user has no cognito groups at all", async () => {
+    it('shows error when user has no cognito groups at all', async () => {
       const token = buildJwt({});
       mockSignIn.mockResolvedValue(undefined);
       mockFetchAuthSession.mockResolvedValue({
@@ -252,58 +240,50 @@ describe("CaseManagerLoginPage", () => {
       });
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "user@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "password123");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'user@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'password123');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText(
-            "You are not authorized as a case manager.",
-          ),
-        ).toBeInTheDocument();
+        expect(screen.getByText('You are not authorized as a case manager.')).toBeInTheDocument();
       });
     });
   });
 
-  describe("Sign-in errors", () => {
-    it("shows the error message from the caught exception", async () => {
-      mockSignIn.mockRejectedValue(new Error("Invalid credentials"));
+  describe('Sign-in errors', () => {
+    it('shows the error message from the caught exception', async () => {
+      mockSignIn.mockRejectedValue(new Error('Invalid credentials'));
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "wrong");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Invalid credentials"),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
       });
     });
 
-    it("falls back to generic error when exception has no message", async () => {
+    it('falls back to generic error when exception has no message', async () => {
       mockSignIn.mockRejectedValue({});
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "wrong");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Something went wrong. Please try again."),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
       });
     });
 
-    it("calls signOut during error cleanup", async () => {
-      mockSignIn.mockRejectedValue(new Error("fail"));
+    it('calls signOut during error cleanup', async () => {
+      mockSignIn.mockRejectedValue(new Error('fail'));
 
       renderPage();
-      await userEvent.type(screen.getByLabelText("Email"), "cm@test.com");
-      await userEvent.type(screen.getByLabelText("Password"), "wrong");
-      fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+      await userEvent.type(screen.getByLabelText('Email'), 'cm@test.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+      fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
 
       await waitFor(() => {
         expect(mockSignOut).toHaveBeenCalled();
@@ -311,19 +291,19 @@ describe("CaseManagerLoginPage", () => {
     });
   });
 
-  describe("Navigation", () => {
-    it("navigates to login page when Back is clicked", async () => {
+  describe('Navigation', () => {
+    it('navigates to login page when Back is clicked', async () => {
       renderPage();
       fireEvent.click(screen.getByText(/Back$/));
 
-      expect(mockNavigate).toHaveBeenCalledWith("/login");
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
     });
 
-    it("navigates to home when Back to Home is clicked", async () => {
+    it('navigates to home when Back to Home is clicked', async () => {
       renderPage();
-      fireEvent.click(screen.getByText("Back to Home"));
+      fireEvent.click(screen.getByText('Back to Home'));
 
-      expect(mockNavigate).toHaveBeenCalledWith("/");
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
 });

--- a/src/Modules/Family/EditFamilyContainer.tsx
+++ b/src/Modules/Family/EditFamilyContainer.tsx
@@ -26,6 +26,7 @@ const EditFamilyContainer: React.FC = () => {
     watch,
     setValue,
     trigger,
+    control,
   } = useForm<RegistrationFormData>();
 
   const onSubmit = (data: RegistrationFormData) => {
@@ -95,6 +96,7 @@ const EditFamilyContainer: React.FC = () => {
                     watch={watch}
                     setValue={setValue}
                     trigger={trigger}
+                    control={control}
                   />
                   <MemberCountFormComponent
                     register={register}

--- a/src/Modules/Family/FamilyContainer.tsx
+++ b/src/Modules/Family/FamilyContainer.tsx
@@ -28,6 +28,7 @@ const FamilyContainer: React.FC<FamilyContainerProps> = ({
     setValue,
     watch,
     trigger,
+    control,
     formState: { errors, isSubmitting },
   } = useForm<RegistrationFormData>({
     mode: 'onChange',
@@ -79,6 +80,7 @@ const FamilyContainer: React.FC<FamilyContainerProps> = ({
                     watch={watch}
                     getValues={getValues}
                     trigger={trigger}
+                    control={control}
                   />
                 </div>
 

--- a/src/Modules/Family/PrimaryInfoFormComponent.tsx
+++ b/src/Modules/Family/PrimaryInfoFormComponent.tsx
@@ -6,6 +6,8 @@ import {
   UseFormGetValues,
   UseFormTrigger,
   FieldErrors,
+  Control,
+  useWatch,
 } from 'react-hook-form';
 import localization from '../Localization/LocalizationComponent';
 import { Button } from '../../components/ui/button';
@@ -30,10 +32,18 @@ interface PrimaryInfoFormComponentProps {
   getValues: UseFormGetValues<RegistrationFormData>;
   trigger: UseFormTrigger<RegistrationFormData>;
   errors: FieldErrors<RegistrationFormData>;
+  /** RHF control object — enables useWatch subscriptions for reliable select reactivity. */
+  control: Control<RegistrationFormData>;
   continueHandler?: (values: Partial<RegistrationFormData>) => void;
   className?: string;
   'data-testid'?: string;
   isHouseholdSetup?: boolean;
+  /** Pre-resolved value for the gender Radix UI Select (watched in the form owner). */
+  genderValue?: string;
+  /** Pre-resolved value for the suffix Radix UI Select (watched in the form owner). */
+  suffixValue?: string;
+  /** Pre-resolved value for the preferred-language Radix UI Select (watched in the form owner). */
+  preferredLanguageValue?: string;
 }
 
 const SUFFIX_NONE_VALUE = 'none';
@@ -45,15 +55,41 @@ const PrimaryInfoFormComponent: React.FC<PrimaryInfoFormComponentProps> = ({
   getValues,
   trigger,
   errors,
+  control,
   continueHandler,
   className = '',
   'data-testid': testId = 'primary-info-form-component',
   isHouseholdSetup = false,
+  genderValue: genderValueProp,
+  suffixValue: suffixValueProp,
+  preferredLanguageValue: preferredLanguageValueProp,
 }) => {
+  // useWatch sets up an RHF subscription that fires reliably after both reset()
+  // and setValue().  Fall back to the parent-supplied prop for backward
+  // compatibility when control is not available (standalone/test usage).
+  const genderFromWatch = useWatch({ control, name: 'gender' });
+  const suffixFromWatch = useWatch({ control, name: 'suffix' });
+  const langFromWatch = useWatch({ control, name: 'preferred_language' });
+
   const date_of_birth = watch('date_of_birth') || '';
-  const suffixValue = watch('suffix') || '';
-  const genderValue = watch('gender') || '';
-  const preferredLanguageValue = watch('preferred_language') || '';
+  const suffixValue =
+    suffixFromWatch != null
+      ? suffixFromWatch
+      : suffixValueProp !== undefined
+        ? suffixValueProp
+        : '';
+  const genderValue =
+    genderFromWatch != null
+      ? genderFromWatch
+      : genderValueProp !== undefined
+        ? genderValueProp
+        : '';
+  const preferredLanguageValue =
+    langFromWatch != null
+      ? langFromWatch
+      : preferredLanguageValueProp !== undefined
+        ? preferredLanguageValueProp
+        : 'en';
 
   useEffect(() => {
     if (!isHouseholdSetup) return;
@@ -67,7 +103,13 @@ const PrimaryInfoFormComponent: React.FC<PrimaryInfoFormComponentProps> = ({
 
   const handleContinue = async () => {
     const values = getValues();
-    const result = await trigger(['first_name', 'last_name', 'date_of_birth', 'gender']);
+    const result = await trigger([
+      'first_name',
+      'last_name',
+      'date_of_birth',
+      'gender',
+      ...(isHouseholdSetup ? (['preferred_language'] as const) : []),
+    ]);
     if (result && continueHandler) {
       continueHandler(values);
     }

--- a/src/Modules/Family/__test__/EditFamilyContainer.test.tsx
+++ b/src/Modules/Family/__test__/EditFamilyContainer.test.tsx
@@ -29,8 +29,11 @@ jest.mock("../AddressComponent", () => ({
 
 jest.mock("../PrimaryInfoFormComponent", () => ({
 	__esModule: true,
-	default: ({ register, errors, getValues }: any) => (
-		<div data-testid="primary-info-component">
+	default: ({ register, errors, getValues, control }: any) => (
+		<div
+			data-testid="primary-info-component"
+			data-has-control={control ? "true" : "false"}
+		>
 			<input
 				{...register("first_name")}
 				data-testid="first-name"
@@ -90,6 +93,8 @@ const mockReset = jest.fn();
 const mockErrors = {};
 const mockWatch = jest.fn();
 const mockSetValue = jest.fn();
+const mockTrigger = jest.fn();
+const mockControl = {};
 
 jest.mock("react-hook-form", () => ({
 	useForm: () => ({
@@ -100,6 +105,8 @@ jest.mock("react-hook-form", () => ({
 		reset: mockReset,
 		watch: mockWatch,
 		setValue: mockSetValue,
+		trigger: mockTrigger,
+		control: mockControl,
 	}),
 }));
 
@@ -284,9 +291,11 @@ describe("EditFamilyContainer", () => {
 			renderEditFamilyContainer();
 			await finishInitialLoading();
 
-			expect(
-				screen.getByTestId("primary-info-component")
-			).toBeInTheDocument();
+			expect(screen.getByTestId("primary-info-component")).toBeInTheDocument();
+			expect(screen.getByTestId("primary-info-component")).toHaveAttribute(
+				"data-has-control",
+				"true"
+			);
 		});
 
 		it("passes correct props to MemberCountFormComponent", async () => {

--- a/src/Modules/Family/__test__/FamilyContainer.test.tsx
+++ b/src/Modules/Family/__test__/FamilyContainer.test.tsx
@@ -21,7 +21,7 @@ jest.mock('../../Registration/RegistrationTextComponent', () => {
 jest.mock('../PrimaryInfoFormComponent', () => {
   return function MockPrimaryInfoFormComponent(props: any) {
     return (
-      <div data-testid="primary-info-form">
+      <div data-testid="primary-info-form" data-has-control={props.control ? 'true' : 'false'}>
         <input name="first_name" data-testid="first-name-input" />
         <input name="last_name" data-testid="last-name-input" />
         <input name="date_of_birth" data-testid="date-of-birth-input" />
@@ -172,6 +172,12 @@ describe('FamilyContainer', () => {
       expect(screen.getByTestId('address-component')).toBeInTheDocument();
       expect(screen.getByTestId('contact-information-component')).toBeInTheDocument();
       expect(screen.getByTestId('member-count-component')).toBeInTheDocument();
+    });
+
+    test('should pass form control to primary info form', () => {
+      renderFamilyContainer();
+
+      expect(screen.getByTestId('primary-info-form')).toHaveAttribute('data-has-control', 'true');
     });
 
     test('should render submit button', () => {

--- a/src/Modules/Family/__test__/PrimaryInfoFormComponent.test.tsx
+++ b/src/Modules/Family/__test__/PrimaryInfoFormComponent.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PrimaryInfoFormComponent from '../PrimaryInfoFormComponent';
+import { Control } from 'react-hook-form';
+
+import { useWatch } from 'react-hook-form';
+
+// Mock useWatch so tests don't depend on a real RHF control instance.
+// Individual tests override the mock when they need specific return values.
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+  useWatch: jest.fn().mockReturnValue(undefined),
+}));
 
 jest.mock('../../Localization/LocalizationComponent', () => ({
   register_who_are_you: 'Who are you?',
@@ -53,6 +63,7 @@ const mockSetValue = jest.fn();
 const mockGetValues = jest.fn();
 const mockTrigger = jest.fn();
 const mockErrors = {};
+const mockControl = {} as Control<any>;
 
 const defaultProps = {
   register: mockRegister,
@@ -61,6 +72,7 @@ const defaultProps = {
   getValues: mockGetValues,
   trigger: mockTrigger,
   errors: mockErrors,
+  control: mockControl,
   continueHandler: jest.fn(),
 };
 
@@ -68,6 +80,8 @@ describe('PrimaryInfoFormComponent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockWatch.mockReturnValue('');
+    // Default: useWatch returns undefined so prop/fallback values take over.
+    (useWatch as jest.Mock).mockReturnValue(undefined);
     mockRegister.mockImplementation((name, options) => ({
       name,
       onChange: jest.fn(),
@@ -525,6 +539,101 @@ describe('PrimaryInfoFormComponent', () => {
       expect(() => {
         unmount();
       }).not.toThrow();
+    });
+  });
+
+  describe('Pre-filled Select Values (useWatch-based)', () => {
+    test('should display gender value returned by useWatch', () => {
+      // Simulate the form returning 'female' via useWatch (as happens after reset + setValue).
+      (useWatch as jest.Mock).mockImplementation(({ name }: { name: string }) => {
+        if (name === 'gender') return 'female';
+        return undefined;
+      });
+
+      renderComponent();
+
+      const genderTrigger = screen.getByTestId('gender-select');
+      expect(genderTrigger).toHaveTextContent('Female');
+    });
+
+    test('should fall back to genderValue prop when useWatch returns undefined', () => {
+      // useWatch returns undefined (field not yet registered) — prop should be used.
+      (useWatch as jest.Mock).mockReturnValue(undefined);
+
+      renderComponent({ genderValue: 'female' });
+
+      const genderTrigger = screen.getByTestId('gender-select');
+      expect(genderTrigger).toHaveTextContent('Female');
+    });
+
+    test('should display suffix value returned by useWatch', () => {
+      (useWatch as jest.Mock).mockImplementation(({ name }: { name: string }) => {
+        if (name === 'suffix') return 'Jr';
+        return undefined;
+      });
+
+      renderComponent();
+
+      const suffixTrigger = screen.getByTestId('suffix-select');
+      expect(suffixTrigger).toHaveTextContent('Jr');
+    });
+
+    test('should fall back to suffixValue prop when useWatch returns undefined', () => {
+      (useWatch as jest.Mock).mockReturnValue(undefined);
+
+      renderComponent({ suffixValue: 'Sr' });
+
+      const suffixTrigger = screen.getByTestId('suffix-select');
+      expect(suffixTrigger).toHaveTextContent('Sr');
+    });
+
+    test('should display preferred language value from useWatch in household setup mode', () => {
+      (useWatch as jest.Mock).mockImplementation(({ name }: { name: string }) => {
+        if (name === 'preferred_language') return 'en';
+        return undefined;
+      });
+
+      renderComponent({ isHouseholdSetup: true });
+
+      const langTrigger = screen.getByTestId('preferred-language-select');
+      expect(langTrigger).toHaveTextContent('English');
+    });
+
+    test('should fall back to preferredLanguageValue prop when useWatch returns undefined', () => {
+      (useWatch as jest.Mock).mockReturnValue(undefined);
+
+      renderComponent({ isHouseholdSetup: true, preferredLanguageValue: 'en' });
+
+      const langTrigger = screen.getByTestId('preferred-language-select');
+      expect(langTrigger).toHaveTextContent('English');
+    });
+
+    test('should show no selection when gender is empty and useWatch returns undefined', () => {
+      (useWatch as jest.Mock).mockReturnValue(undefined);
+
+      renderComponent({ genderValue: '' });
+
+      const genderTrigger = screen.getByTestId('gender-select');
+      expect(genderTrigger).toBeInTheDocument();
+    });
+
+    test('should validate only required fields (no preferred_language) in non-setup mode', async () => {
+      const user = userEvent.setup();
+      mockTrigger.mockResolvedValue(true);
+      mockGetValues.mockReturnValue({});
+      const mockContinueHandler = jest.fn();
+
+      renderComponent({ continueHandler: mockContinueHandler });
+
+      const continueButton = screen.getByTestId('continue-button');
+      await user.click(continueButton);
+
+      expect(mockTrigger).toHaveBeenCalledWith([
+        'first_name',
+        'last_name',
+        'date_of_birth',
+        'gender',
+      ]);
     });
   });
 });

--- a/src/Modules/Family/__test__/coreComponentsIntegration.test.tsx
+++ b/src/Modules/Family/__test__/coreComponentsIntegration.test.tsx
@@ -3,10 +3,17 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { Control } from 'react-hook-form';
 import FamilyContainer from '../FamilyContainer';
 import PrimaryInfoFormComponent from '../PrimaryInfoFormComponent';
 import AddressComponent from '../AddressComponent';
 import ContactInformationComponent from '../ContactInformationComponent';
+
+// Stub useWatch so PrimaryInfoFormComponent can render without a real RHF control.
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+  useWatch: jest.fn().mockReturnValue(undefined),
+}));
 
 // Mock Redux store
 const mockStore = configureStore({
@@ -108,6 +115,7 @@ const mockGetValues = jest.fn();
 const mockHandleSubmit = jest.fn();
 const mockTrigger = jest.fn();
 const mockErrors = {};
+const mockControl = {} as Control<any>;
 
 // Default form props for testing
 const defaultFormProps = {
@@ -118,6 +126,7 @@ const defaultFormProps = {
   watch: mockWatch,
   handleSubmit: mockHandleSubmit,
   trigger: mockTrigger,
+  control: mockControl,
 };
 
 // Wrapper component for testing with Redux

--- a/src/Modules/Family/__test__/responsiveDesignValidation.test.tsx
+++ b/src/Modules/Family/__test__/responsiveDesignValidation.test.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { Control } from 'react-hook-form';
 import FamilyContainer from '../FamilyContainer';
 import PrimaryInfoFormComponent from '../PrimaryInfoFormComponent';
 import AddressComponent from '../AddressComponent';
 import ContactInformationComponent from '../ContactInformationComponent';
+
+// Stub useWatch so PrimaryInfoFormComponent can render without a real RHF control.
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+  useWatch: jest.fn().mockReturnValue(undefined),
+}));
 
 // Mock Redux store
 const mockStore = configureStore({
@@ -53,6 +60,7 @@ const mockGetValues = jest.fn();
 const mockHandleSubmit = jest.fn();
 const mockTrigger = jest.fn();
 const mockErrors = {};
+const mockControl = {} as Control<any>;
 
 // Default form props for testing
 const defaultFormProps = {
@@ -63,6 +71,7 @@ const defaultFormProps = {
   watch: mockWatch,
   handleSubmit: mockHandleSubmit,
   trigger: mockTrigger,
+  control: mockControl,
 };
 
 // Wrapper component for testing with Redux

--- a/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
+++ b/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
@@ -4,7 +4,7 @@
  * This component now uses the unified HouseholdForm component for consistency.
  */
 
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useAuth } from '../../Authentication/AuthContext';
 
 // Component imports
@@ -38,6 +38,11 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
 
   // Memoized API service instance
   const householdsApiService = useMemo(() => new HouseholdsApiService(), []);
+
+  // Set to true once /users/me returns a primary member. Used by the authUser
+  // effect below to avoid overwriting API-sourced names with the coarser
+  // Cognito display-name split if useAuth resolves after the API call.
+  const apiDataLoadedRef = useRef<boolean>(false);
 
   // Component state — start loading immediately so the form never renders before API data arrives
   const [isLoadingUserData, setIsLoadingUserData] = useState<boolean>(true);
@@ -111,6 +116,11 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
               ? getLanguageOptionById(userData.language_id)?.code
               : undefined) ??
             'en';
+          // Mark that authoritative API data is available. The authUser effect
+          // checks this flag so it never replaces API-sourced names with the
+          // coarser Cognito display-name split, regardless of which effect
+          // resolves first.
+          apiDataLoadedRef.current = true;
           setPrefilledData({
             first_name: primaryMember.first_name || '',
             last_name: primaryMember.last_name || '',
@@ -149,9 +159,14 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
     fetchUserData();
   }, [householdsApiService]);
 
-  // Pre-populate with auth user data if available
+  // Pre-populate with auth user data as a fallback only when the /users/me
+  // API has not already returned a primary member. If the API effect ran
+  // first (apiDataLoadedRef = true), we keep those API-sourced names because
+  // they are the ground truth; the Cognito display name is a coarser signal
+  // (a single string split on the first space) that can't be trusted to
+  // reconstruct separate first/last names reliably.
   useEffect(() => {
-    if (authUser) {
+    if (authUser && !apiDataLoadedRef.current) {
       const nameParts = authUser.name?.split(' ') || [];
       setPrefilledData((prev) => ({
         ...prev,

--- a/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
+++ b/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
@@ -152,15 +152,13 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
             children_in_household: additionalCounts.children,
           });
         } else {
-          // No members yet (new household or all members removed). Still apply
-          // household-level preferences from the API and lock the gate so the
-          // authUser effect cannot flip permission_to_email back to true after
-          // the API has already indicated the user's actual preference.
-          //
-          // We merge rather than replace so that name fields supplied by the
-          // authUser effect (which runs synchronously before this async branch
-          // resolves) are preserved — there is no API member to source them from.
-          apiDataLoadedRef.current = true;
+          // No members yet (new household or all members removed). Apply
+          // household-level preferences (address, contact prefs) from the API
+          // via functional merge so they take effect without blocking the authUser
+          // name fallback. We intentionally do NOT set apiDataLoadedRef here:
+          // the API returned no member names, so Cognito names remain the best
+          // available source and the authUser effect must be allowed to run if
+          // authUser resolves after this branch completes.
           setPrefilledData((prev) => ({ ...prev, ...householdFields }));
         }
       } catch (error) {
@@ -177,11 +175,16 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
   }, [householdsApiService]);
 
   // Pre-populate with auth user data as a fallback only when the /users/me
-  // API has not already returned a primary member. If the API effect ran
-  // first (apiDataLoadedRef = true), we keep those API-sourced names because
-  // they are the ground truth; the Cognito display name is a coarser signal
-  // (a single string split on the first space) that can't be trusted to
-  // reconstruct separate first/last names reliably.
+  // API has not already returned a primary member. If the API effect ran first
+  // with member data (apiDataLoadedRef = true), those API-sourced names are
+  // authoritative — a Cognito display name split on the first space cannot
+  // reliably reconstruct separate first/last names.
+  //
+  // When the API returned no members (apiDataLoadedRef = false), the authUser
+  // effect is still allowed to run so names are filled from Cognito. In that
+  // case we use `prev.permission_to_email ?? true` so that if the API merge
+  // already wrote a `false` preference into prev, it is preserved.  The `??`
+  // only falls back to `true` when the field is still undefined (pre-API state).
   useEffect(() => {
     if (authUser && !apiDataLoadedRef.current) {
       const nameParts = authUser.name?.split(' ') || [];
@@ -190,7 +193,7 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
         first_name: nameParts[0] || '',
         last_name: nameParts.slice(1).join(' ') || '',
         email: authUser.email || '',
-        permission_to_email: true,
+        permission_to_email: prev.permission_to_email ?? true,
       }));
     }
   }, [authUser]);

--- a/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
+++ b/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
@@ -39,8 +39,8 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
   // Memoized API service instance
   const householdsApiService = useMemo(() => new HouseholdsApiService(), []);
 
-  // Component state
-  const [isLoadingUserData, setIsLoadingUserData] = useState<boolean>(false);
+  // Component state — start loading immediately so the form never renders before API data arrives
+  const [isLoadingUserData, setIsLoadingUserData] = useState<boolean>(true);
   const [prefilledData, setPrefilledData] = useState<Partial<RegistrationFormData>>({});
   const [currentHouseholdMembers, setCurrentHouseholdMembers] = useState<ApiHouseholdMember[]>([]);
   const [deletedMemberIds, setDeletedMemberIds] = useState<number[]>([]);

--- a/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
+++ b/src/Modules/Households/components/HouseholdRegistrationComponent.tsx
@@ -76,31 +76,57 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
     }
   };
 
-  // Pre-populate form with primary member data from /users/me
+  // Pre-populate form with data from /users/me
   useEffect(() => {
     const fetchUserData = async () => {
       setIsLoadingUserData(true);
       try {
         const userData = await householdsApiService.getUsersMe();
 
-        // Pre-populate primary member data if available
-        if (userData && userData.members && userData.members.length > 0) {
+        // Convert gender_id to the lowercase string form expected by the form.
+        const getGenderForForm = (genderId: number | null): string => {
+          if (!genderId) return '';
+          const gender = getGenderFromId(genderId);
+          if (!gender) return '';
+          const genderMap: Record<string, string> = {
+            male: 'male',
+            female: 'female',
+            other: 'other',
+            prefer_not_to_say: 'not_specify',
+          };
+          return genderMap[gender] || '';
+        };
+
+        const preferredLang =
+          (userData.preferred_language && getLanguageCodes().includes(userData.preferred_language)
+            ? userData.preferred_language
+            : null) ??
+          (typeof userData.language_id === 'number'
+            ? getLanguageOptionById(userData.language_id)?.code
+            : undefined) ??
+          'en';
+
+        // Household-level fields (address, contact preferences, language) are
+        // always applied when the API call succeeds, even when no members exist
+        // yet. This prevents the authUser fallback from overwriting API-sourced
+        // preferences (e.g. permission_to_email: false) for a newly-created
+        // household that hasn't added members yet.
+        const householdFields = {
+          preferred_language: preferredLang,
+          phone: userData.phone || '',
+          email: userData.email || '',
+          address_line_1: userData.address_line_1 || '',
+          address_line_2: userData.address_line_2 || '',
+          city: userData.city || '',
+          state: userData.state || '',
+          zip_code: userData.zip_code || '',
+          permission_to_text: userData.permission_to_text ?? false,
+          permission_to_email: userData.permission_to_email ?? false,
+        };
+
+        if (userData.members && userData.members.length > 0) {
           setCurrentHouseholdMembers(userData.members);
           const primaryMember = userData.members[0];
-
-          // Convert gender_id to form value (lowercase format expected by form)
-          const getGenderForForm = (genderId: number | null): string => {
-            if (!genderId) return '';
-            const gender = getGenderFromId(genderId);
-            if (!gender) return '';
-            const genderMap: Record<string, string> = {
-              male: 'male',
-              female: 'female',
-              other: 'other',
-              prefer_not_to_say: 'not_specify',
-            };
-            return genderMap[gender] || '';
-          };
 
           // Compute additional-member counts (excludes HOH from the correct age bucket)
           const additionalCounts = getAdditionalMemberCounts(
@@ -108,48 +134,39 @@ const HouseholdRegistrationComponent: React.FC<HouseholdRegistrationComponentPro
             primaryMember.date_of_birth,
           );
 
-          const preferredLang =
-            (userData.preferred_language && getLanguageCodes().includes(userData.preferred_language)
-              ? userData.preferred_language
-              : null) ??
-            (typeof userData.language_id === 'number'
-              ? getLanguageOptionById(userData.language_id)?.code
-              : undefined) ??
-            'en';
           // Mark that authoritative API data is available. The authUser effect
           // checks this flag so it never replaces API-sourced names with the
           // coarser Cognito display-name split, regardless of which effect
           // resolves first.
           apiDataLoadedRef.current = true;
           setPrefilledData({
+            ...householdFields,
             first_name: primaryMember.first_name || '',
             last_name: primaryMember.last_name || '',
             middle_name: primaryMember.middle_name || '',
             suffix: getSuffixFromId(primaryMember.suffix_id),
             date_of_birth: convertDateFormat(primaryMember.date_of_birth || ''),
             gender: getGenderForForm(primaryMember.gender_id || null),
-            preferred_language: preferredLang,
-            phone: userData.phone || '',
-            email: userData.email || '',
-            address_line_1: userData.address_line_1 || '',
-            address_line_2: userData.address_line_2 || '',
-            city: userData.city || '',
-            state: userData.state || '',
-            zip_code: userData.zip_code || '',
-            // Contact preferences
-            permission_to_text: userData.permission_to_text ?? false,
-            permission_to_email: userData.permission_to_email ?? false,
             seniors_in_household: additionalCounts.seniors,
             adults_in_household: additionalCounts.adults,
             children_in_household: additionalCounts.children,
           });
         } else {
-          // No members found - set empty prefilled data
-          console.error('No members found in user data');
+          // No members yet (new household or all members removed). Still apply
+          // household-level preferences from the API and lock the gate so the
+          // authUser effect cannot flip permission_to_email back to true after
+          // the API has already indicated the user's actual preference.
+          //
+          // We merge rather than replace so that name fields supplied by the
+          // authUser effect (which runs synchronously before this async branch
+          // resolves) are preserved — there is no API member to source them from.
+          apiDataLoadedRef.current = true;
+          setPrefilledData((prev) => ({ ...prev, ...householdFields }));
         }
       } catch (error) {
         console.error('Error fetching user data:', error);
-        // Still allow the form to proceed even if API fails
+        // Still allow the form to proceed even if API fails.
+        // apiDataLoadedRef stays false, so the authUser effect provides fallback.
       } finally {
         // Always set loading to false to prevent infinite spinner
         setIsLoadingUserData(false);

--- a/src/Modules/Households/components/HouseholdSignUpWrapper.tsx
+++ b/src/Modules/Households/components/HouseholdSignUpWrapper.tsx
@@ -33,7 +33,6 @@ interface HouseholdSignUpWrapperProps {
  */
 export const HouseholdSignUpWrapper: React.FC<HouseholdSignUpWrapperProps> = ({
   children,
-  onSignUpSuccess,
   onSignUpError,
 }) => {
   const { user, isAuthenticated, needsHouseholdSetup, setNeedsHouseholdSetup } = useAuth();

--- a/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
+++ b/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import HouseholdRegistrationComponent from '../HouseholdRegistrationComponent';
 
 // ---------------------------------------------------------------------------
@@ -225,7 +225,44 @@ describe('HouseholdRegistrationComponent', () => {
       // authUser fires first (synchronous), API merges on top — names preserved.
       expect(lastCall.prefilledData.first_name).toBe('Cognito');
       expect(lastCall.prefilledData.last_name).toBe('User');
-      // API-sourced preference must survive; authUser sets permission_to_email: true.
+      // API-sourced preference must survive; authUser would have set true.
+      expect(lastCall.prefilledData.permission_to_email).toBe(false);
+    });
+
+    it('fills Cognito names when API returns no members and authUser arrives after the API resolves', async () => {
+      // Simulate authUser being null on first render so the API effect runs first,
+      // then authUser resolves later and the names should still be filled.
+      mockUseAuth.mockReturnValue({ user: null });
+
+      let resolveGetUsersMe!: (v: unknown) => void;
+      mockGetUsersMe.mockReturnValue(
+        new Promise((res) => {
+          resolveGetUsersMe = res;
+        }),
+      );
+
+      const { rerender } = renderComponent();
+
+      // Resolve the API with no members while authUser is still null.
+      await act(async () => {
+        resolveGetUsersMe({ members: [], counts: {}, permission_to_email: false });
+      });
+
+      // Now authUser resolves — re-render with the Cognito user available.
+      mockUseAuth.mockReturnValue({ user: cognitoUser });
+      rerender(<HouseholdRegistrationComponent onComplete={onComplete} onCancel={onCancel} />);
+
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      // Names must come from Cognito (API provided none).
+      expect(lastCall.prefilledData.first_name).toBe('Cognito');
+      expect(lastCall.prefilledData.last_name).toBe('User');
+      // API-sourced preference must still win (prev.permission_to_email ?? true).
       expect(lastCall.prefilledData.permission_to_email).toBe(false);
     });
 

--- a/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
+++ b/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
@@ -129,7 +129,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.first_name).toBe('Jane');
@@ -147,7 +149,9 @@ describe('HouseholdRegistrationComponent', () => {
       // Re-render with updated auth context value would not happen automatically in this test
       // since useAuth is a hook called on render. The ref check prevents overwrite, so we
       // verify the form received API names in the last call before auth re-resolution.
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.first_name).toBe('Jane');
@@ -161,7 +165,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.email).toBe('jane@api.com');
@@ -172,7 +178,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.permission_to_email).toBe(false);
@@ -185,7 +193,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       // "Cognito User" split on first space → first="Cognito", last="User"
@@ -193,16 +203,30 @@ describe('HouseholdRegistrationComponent', () => {
       expect(lastCall.prefilledData.last_name).toBe('User');
     });
 
-    it('falls back to Cognito names when API returns no members', async () => {
-      mockGetUsersMe.mockResolvedValue({ members: [], counts: {} });
+    it('preserves Cognito names but applies API preferences when API returns no members', async () => {
+      // When the household exists but has no members yet, the API still carries
+      // household-level preferences (address, permission_to_email, etc.).  The
+      // component should merge: names from the synchronous Cognito fallback are
+      // kept (no member API source), but contact preferences from the API win.
+      mockGetUsersMe.mockResolvedValue({
+        members: [],
+        counts: {},
+        permission_to_email: false, // API says no email — must NOT be flipped to true
+        permission_to_text: false,
+      });
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
+      // authUser fires first (synchronous), API merges on top — names preserved.
       expect(lastCall.prefilledData.first_name).toBe('Cognito');
       expect(lastCall.prefilledData.last_name).toBe('User');
+      // API-sourced preference must survive; authUser sets permission_to_email: true.
+      expect(lastCall.prefilledData.permission_to_email).toBe(false);
     });
 
     it('falls back to Cognito email when API fails', async () => {
@@ -210,7 +234,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.email).toBe('cognito@test.com');
@@ -231,7 +257,9 @@ describe('HouseholdRegistrationComponent', () => {
       renderComponent();
       await screen.findByTestId('household-form');
 
-      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+      const lastCall = mockHouseholdForm.mock.calls[
+        mockHouseholdForm.mock.calls.length - 1
+      ]?.[0] as {
         prefilledData: Record<string, unknown>;
       };
       expect(lastCall.prefilledData.address_line_1).toBe('123 API St');

--- a/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
+++ b/src/Modules/Households/components/__tests__/HouseholdRegistrationComponent.test.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import HouseholdRegistrationComponent from '../HouseholdRegistrationComponent';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const mockGetUsersMe = jest.fn();
+jest.mock('../../../../Services/HouseholdsApiService', () => ({
+  HouseholdsApiService: jest.fn().mockImplementation(() => ({
+    getUsersMe: (...args: unknown[]) => mockGetUsersMe(...args),
+  })),
+}));
+
+// Capture the prefilledData prop so tests can assert on it without a full form render.
+const mockHouseholdForm = jest.fn();
+jest.mock('../../../../components/shared', () => ({
+  HouseholdForm: (props: Record<string, unknown>) => {
+    mockHouseholdForm(props);
+    return <div data-testid="household-form" />;
+  },
+}));
+
+jest.mock('../LoadingSpinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading-spinner" />,
+}));
+
+jest.mock('../../../Localization/LocalizationComponent', () => ({
+  title_set_up_household: 'Set up household',
+  subtitle_complete_household_profile: 'Complete your profile',
+  button_complete_setup: 'Complete',
+  button_cancel: 'Cancel',
+}));
+
+jest.mock('../../../Localization/languageOptions', () => ({
+  getLanguageCodes: () => ['en', 'es'],
+  getLanguageOptionById: () => null,
+}));
+
+jest.mock('../../utils/householdUtils', () => ({
+  getGenderFromId: jest.fn(() => 'female'),
+  getSuffixFromId: jest.fn(() => ''),
+  getAdditionalMemberCounts: jest.fn(() => ({ seniors: 0, adults: 1, children: 0 })),
+}));
+
+// Controlled authUser mock — reassigned per test via mockUseAuth.
+const mockUseAuth = jest.fn();
+jest.mock('../../../Authentication/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const apiMemberData = {
+  members: [
+    {
+      user_id: '1',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      middle_name: '',
+      suffix_id: null,
+      gender_id: 2,
+      date_of_birth: '1985-06-15',
+    },
+  ],
+  address_line_1: '123 API St',
+  city: 'Springfield',
+  state: 'IL',
+  zip_code: '62701',
+  phone: '5551234567',
+  email: 'jane@api.com',
+  permission_to_text: true,
+  permission_to_email: false,
+  counts: { seniors: 0, adults: 1, children: 0 },
+};
+
+const cognitoUser = { name: 'Cognito User', email: 'cognito@test.com' };
+
+const onComplete = jest.fn();
+const onCancel = jest.fn();
+
+function renderComponent() {
+  return render(<HouseholdRegistrationComponent onComplete={onComplete} onCancel={onCancel} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HouseholdRegistrationComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUsersMe.mockResolvedValue(apiMemberData);
+    mockUseAuth.mockReturnValue({ user: cognitoUser });
+  });
+
+  describe('loading state', () => {
+    it('shows spinner while the API fetch is in-flight', () => {
+      // Never resolves during this test
+      mockGetUsersMe.mockReturnValue(new Promise(() => {}));
+      renderComponent();
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+      expect(screen.queryByTestId('household-form')).not.toBeInTheDocument();
+    });
+
+    it('removes spinner and renders form once API resolves', async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByTestId('household-form')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    });
+
+    it('removes spinner and renders form even when API fails', async () => {
+      mockGetUsersMe.mockRejectedValue(new Error('Network error'));
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByTestId('household-form')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('API data vs Cognito name precedence', () => {
+    it('passes API-sourced first/last names to HouseholdForm when API succeeds', async () => {
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.first_name).toBe('Jane');
+      expect(lastCall.prefilledData.last_name).toBe('Doe');
+    });
+
+    it('does not overwrite API names with Cognito display-name split when authUser resolves after API', async () => {
+      // API resolves first
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      // Simulate authUser resolving later by re-rendering with a new (but equivalent) user ref.
+      // This triggers the authUser effect again with apiDataLoadedRef already true.
+      mockUseAuth.mockReturnValue({ user: { ...cognitoUser, name: 'Should Not Appear' } });
+      // Re-render with updated auth context value would not happen automatically in this test
+      // since useAuth is a hook called on render. The ref check prevents overwrite, so we
+      // verify the form received API names in the last call before auth re-resolution.
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.first_name).toBe('Jane');
+      expect(lastCall.prefilledData.last_name).toBe('Doe');
+      // Cognito splits the name on the first space — these must NOT appear
+      expect(lastCall.prefilledData.first_name).not.toBe('Should');
+      expect(lastCall.prefilledData.last_name).not.toBe('Not Appear');
+    });
+
+    it('passes API email and not Cognito email', async () => {
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.email).toBe('jane@api.com');
+    });
+
+    it('respects API permission_to_email=false and does not flip it to true via authUser', async () => {
+      // The API returns permission_to_email: false. authUser effect must not overwrite it.
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.permission_to_email).toBe(false);
+    });
+  });
+
+  describe('Cognito fallback when API has no usable data', () => {
+    it('falls back to Cognito names when API call throws', async () => {
+      mockGetUsersMe.mockRejectedValue(new Error('Network error'));
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      // "Cognito User" split on first space → first="Cognito", last="User"
+      expect(lastCall.prefilledData.first_name).toBe('Cognito');
+      expect(lastCall.prefilledData.last_name).toBe('User');
+    });
+
+    it('falls back to Cognito names when API returns no members', async () => {
+      mockGetUsersMe.mockResolvedValue({ members: [], counts: {} });
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.first_name).toBe('Cognito');
+      expect(lastCall.prefilledData.last_name).toBe('User');
+    });
+
+    it('falls back to Cognito email when API fails', async () => {
+      mockGetUsersMe.mockRejectedValue(new Error('Network error'));
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.email).toBe('cognito@test.com');
+    });
+
+    it('renders form with empty prefilledData when both API and authUser are unavailable', async () => {
+      mockGetUsersMe.mockRejectedValue(new Error('Network error'));
+      mockUseAuth.mockReturnValue({ user: null });
+      renderComponent();
+      await screen.findByTestId('household-form');
+      // Should not throw and form should render
+      expect(screen.getByTestId('household-form')).toBeInTheDocument();
+    });
+  });
+
+  describe('address and contact data from API', () => {
+    it('passes API address fields to HouseholdForm', async () => {
+      renderComponent();
+      await screen.findByTestId('household-form');
+
+      const lastCall = mockHouseholdForm.mock.calls.at(-1)?.[0] as {
+        prefilledData: Record<string, unknown>;
+      };
+      expect(lastCall.prefilledData.address_line_1).toBe('123 API St');
+      expect(lastCall.prefilledData.city).toBe('Springfield');
+      expect(lastCall.prefilledData.phone).toBe('5551234567');
+    });
+  });
+});

--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -418,8 +418,14 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
     const isCognitoSignedIn = StorageService.isLoggedInUser();
     const hasRouterHouseholdData = Boolean(location.state?.householdData);
 
-    if (!user || !isCognitoSignedIn || StorageService.isCaseManager() || hasRouterHouseholdData) {
-      // Nothing to fetch — release the loading gate so the form can render.
+    if (!user) {
+      // User not yet initialised — keep the loading gate up and wait for the
+      // next effect run (triggered when user state is set by the auth effect).
+      return;
+    }
+
+    if (!isCognitoSignedIn || StorageService.isCaseManager() || hasRouterHouseholdData) {
+      // Definitely no household fetch needed for this path — release the gate.
       setIsHouseholdPrefillLoading(false);
       return;
     }

--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -157,6 +157,12 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
   const householdDataProcessedRef = useRef<boolean>(false);
   // Guards the API-based prefill (RSVP path) so it only runs once per navigation.
   const householdApiFetchedRef = useRef<boolean>(false);
+  // Monotonically-increasing counter scoped to the current navigation. Incremented
+  // by the location-reset effect whenever location.state changes (new navigation).
+  // Used by the RSVP prefill .finally() to distinguish "user state changed within
+  // the same navigation" (safe to release gate) from "user navigated away" (must
+  // keep gate for the new navigation's fetch).
+  const prefillGenerationRef = useRef<number>(0);
 
   // True while the RSVP-path household prefill fetch is in-flight. Initialized
   // eagerly so the form never renders before prefill settles (avoids late-
@@ -394,6 +400,10 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
 
   // Reset household data processing flags when location changes
   useEffect(() => {
+    // Advance the generation counter so any in-flight RSVP prefill fetch from the
+    // previous navigation knows it has been superseded and must not release the gate
+    // (which now belongs to the new navigation's fetch).
+    prefillGenerationRef.current += 1;
     householdDataProcessedRef.current = false;
     householdApiFetchedRef.current = false;
     // Re-evaluate whether a prefill fetch is needed for this navigation
@@ -411,8 +421,12 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
    * and apply the same mapping used by the router-state path above.
    *
    * isHouseholdPrefillLoading (initialised eagerly) keeps the spinner up until
-   * this fetch settles, so the form only renders with complete data and a late
-   * response can never overwrite input the user has already typed.
+   * this fetch settles, so the form only renders with complete data.
+   *
+   * A `cancelled` flag in the closure ensures that if dependencies change while
+   * the fetch is in-flight (e.g. location.state updates or component unmounts),
+   * the stale response is silently discarded rather than applied to the new
+   * navigation's state or a now-unmounted component.
    */
   useEffect(() => {
     const isCognitoSignedIn = StorageService.isLoggedInUser();
@@ -437,9 +451,23 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
 
     householdApiFetchedRef.current = true;
 
+    // Capture the current navigation generation. The location-reset effect
+    // increments this whenever location.state changes, so .finally() can tell
+    // whether a new navigation started while the fetch was in-flight.
+    const capturedGeneration = prefillGenerationRef.current;
+
+    // Per-effect cancellation flag. Set by the cleanup function when any
+    // dependency changes (including user updating after the .then() applies
+    // household data). Used only in .then()/.catch() to prevent stale data
+    // from being written to state; .finally() uses the generation counter
+    // instead, because cancelled fires on same-navigation user changes too.
+    let cancelled = false;
+
     householdsApiService
       .getUsersMe()
       .then((householdData) => {
+        if (cancelled) return;
+
         const primaryMember =
           householdData.members && householdData.members.length > 0
             ? householdData.members[0]
@@ -483,15 +511,28 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
         }
       })
       .catch((error) => {
+        if (cancelled) return;
         console.error('Error fetching household data for RSVP prefill:', error);
         // Reset the guard so the next RSVP navigation in this session gets a
         // fresh attempt rather than silently staying on stub Cognito data.
         householdApiFetchedRef.current = false;
       })
       .finally(() => {
-        // Always release the loading gate whether the fetch succeeded or failed.
+        // Release the gate only when still within the same navigation.
+        // If the generation advanced (location.state changed) the location-reset
+        // effect has already re-lifted the gate for the new navigation; releasing
+        // it here would allow the form to render before the new fetch completes.
+        // We intentionally do NOT check `cancelled` here: cancelled also fires
+        // when user state changes within the same navigation (e.g. after .then()
+        // applies household data inside act()), which would permanently block the
+        // spinner from clearing.
+        if (prefillGenerationRef.current !== capturedGeneration) return;
         setIsHouseholdPrefillLoading(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, location.state, householdsApiService]);
 
   const handleAuthLogin = (): void => {

--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -220,8 +220,11 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
     setIsError(false);
     setPageError(false);
     setErrors([]);
-    // Allow a fresh RSVP prefill fetch for the new event
+    // Allow a fresh RSVP prefill fetch for the new event and advance the
+    // generation counter so any in-flight fetch from the previous event cannot
+    // release the loading gate that now belongs to the new event.
     householdApiFetchedRef.current = false;
+    prefillGenerationRef.current += 1;
 
     // Always fetch fresh event data based on URL parameter
     if (eventDateId) {
@@ -533,7 +536,7 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
     return () => {
       cancelled = true;
     };
-  }, [user, location.state, householdsApiService]);
+  }, [user, eventDateId, location.state, householdsApiService]);
 
   const handleAuthLogin = (): void => {
     const token = StorageService.getUserToken();

--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -158,6 +158,16 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
   // Guards the API-based prefill (RSVP path) so it only runs once per navigation.
   const householdApiFetchedRef = useRef<boolean>(false);
 
+  // True while the RSVP-path household prefill fetch is in-flight. Initialized
+  // eagerly so the form never renders before prefill settles (avoids late-
+  // clobber of user input if the user starts typing before the API responds).
+  const [isHouseholdPrefillLoading, setIsHouseholdPrefillLoading] = useState<boolean>(
+    () =>
+      StorageService.isLoggedInUser() &&
+      !StorageService.isCaseManager() &&
+      !Boolean(location.state?.householdData),
+  );
+
   const householdsApiService = useMemo(() => new HouseholdsApiService(), []);
 
   const event = useSelector(selectEvent);
@@ -204,6 +214,8 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
     setIsError(false);
     setPageError(false);
     setErrors([]);
+    // Allow a fresh RSVP prefill fetch for the new event
+    householdApiFetchedRef.current = false;
 
     // Always fetch fresh event data based on URL parameter
     if (eventDateId) {
@@ -384,6 +396,12 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
   useEffect(() => {
     householdDataProcessedRef.current = false;
     householdApiFetchedRef.current = false;
+    // Re-evaluate whether a prefill fetch is needed for this navigation
+    setIsHouseholdPrefillLoading(
+      StorageService.isLoggedInUser() &&
+        !StorageService.isCaseManager() &&
+        !Boolean(location.state?.householdData),
+    );
   }, [location.state]);
 
   /**
@@ -391,18 +409,23 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
    * state (i.e. RSVP events that skip the timeslot modal) still deserve full
    * household prefill.  Fetch /users/me once the user object is initialised
    * and apply the same mapping used by the router-state path above.
+   *
+   * isHouseholdPrefillLoading (initialised eagerly) keeps the spinner up until
+   * this fetch settles, so the form only renders with complete data and a late
+   * response can never overwrite input the user has already typed.
    */
   useEffect(() => {
     const isCognitoSignedIn = StorageService.isLoggedInUser();
     const hasRouterHouseholdData = Boolean(location.state?.householdData);
 
-    if (
-      !user ||
-      !isCognitoSignedIn ||
-      StorageService.isCaseManager() ||
-      hasRouterHouseholdData ||
-      householdApiFetchedRef.current
-    ) {
+    if (!user || !isCognitoSignedIn || StorageService.isCaseManager() || hasRouterHouseholdData) {
+      // Nothing to fetch — release the loading gate so the form can render.
+      setIsHouseholdPrefillLoading(false);
+      return;
+    }
+
+    if (householdApiFetchedRef.current) {
+      // Already in-flight or completed for this navigation — do not restart.
       return;
     }
 
@@ -455,6 +478,13 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
       })
       .catch((error) => {
         console.error('Error fetching household data for RSVP prefill:', error);
+        // Reset the guard so the next RSVP navigation in this session gets a
+        // fresh attempt rather than silently staying on stub Cognito data.
+        householdApiFetchedRef.current = false;
+      })
+      .finally(() => {
+        // Always release the loading gate whether the fetch succeeded or failed.
+        setIsHouseholdPrefillLoading(false);
       });
   }, [user, location.state, householdsApiService]);
 
@@ -1030,9 +1060,13 @@ const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
     );
   }
 
-  // Show spinner while loading or if user/event data is not ready
+  // Show spinner while loading, while household prefill is in-flight, or if
+  // user/event data is not ready. The isHouseholdPrefillLoading gate ensures
+  // the form only renders after household data has been fetched, preventing a
+  // late API response from overwriting fields the user already filled in.
   if (
     isLoading ||
+    isHouseholdPrefillLoading ||
     !user ||
     typeof user !== 'object' ||
     !selectedEvent ||

--- a/src/Modules/Registration/RegistrationContainer.tsx
+++ b/src/Modules/Registration/RegistrationContainer.tsx
@@ -1,105 +1,139 @@
-import React, {
-	Fragment,
-	useEffect,
-	useState,
-	useRef,
-	useCallback,
-} from "react";
-import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { useSelector, useDispatch } from "react-redux";
-import config from "../../config";
-import TagManager from "react-gtm-module";
-import { setCurrentEvent, selectEvent } from "../../Store/Events/eventSlice";
-import { selectUser } from "../../Store/userSlice";
-import SpinnerComponent from "../General/SpinnerComponent";
-import ErrorComponent from "../General/ErrorComponent";
-import { API_URL, RENDER_URL } from "../../Utils/Urls";
-import axios from "axios";
-import RegistrationComponent from "./RegistrationComponent";
-import { EventFormat } from "../../Utils/EventHandler";
-import { NotifyToast, showToast } from "../Notifications/NotifyToastComponent";
-import { sendRegistrationConfirmationEmail } from "../../Services/ApiService";
-import AuthenticationModalComponent from "../Authentication/AuthenticationModal";
-import { HouseholdsApiService } from "../../Services/HouseholdsApiService";
+import React, { Fragment, useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import config from '../../config';
+import TagManager from 'react-gtm-module';
+import { setCurrentEvent, selectEvent } from '../../Store/Events/eventSlice';
+import { selectUser } from '../../Store/userSlice';
+import SpinnerComponent from '../General/SpinnerComponent';
+import ErrorComponent from '../General/ErrorComponent';
+import { API_URL, RENDER_URL } from '../../Utils/Urls';
+import axios from 'axios';
+import RegistrationComponent from './RegistrationComponent';
+import { EventFormat } from '../../Utils/EventHandler';
+import { NotifyToast, showToast } from '../Notifications/NotifyToastComponent';
+import { sendRegistrationConfirmationEmail } from '../../Services/ApiService';
+import AuthenticationModalComponent from '../Authentication/AuthenticationModal';
+import { HouseholdsApiService } from '../../Services/HouseholdsApiService';
+import { UsersMeResponse, UpdateHouseholdApiRequest } from '../Households/types/api.types';
+import { handleAuthError, getCognitoToken } from '../../Utils/AuthErrorHandler';
 import {
-	UsersMeResponse,
-	UpdateHouseholdApiRequest,
-} from "../Households/types/api.types";
-import { handleAuthError, getCognitoToken } from "../../Utils/AuthErrorHandler";
-import {
-	getGenderId,
-	getGenderFromId,
-	getSuffixFromId,
-	getSuffixId,
-	getAdditionalMemberCounts,
-} from "../Households/utils/householdUtils";
-import { getLanguageOptionByCode } from "../Localization/languageOptions";
-import { StorageService } from "../../Utils/StorageService";
-import { normalizePhoneInput } from "../Family/utils/phoneFormatting";
+  getGenderId,
+  getGenderFromId,
+  getSuffixFromId,
+  getSuffixId,
+  getAdditionalMemberCounts,
+} from '../Households/utils/householdUtils';
+import { getLanguageOptionByCode } from '../Localization/languageOptions';
+import { StorageService } from '../../Utils/StorageService';
+import { normalizePhoneInput } from '../Family/utils/phoneFormatting';
 
 // Type imports from registration.types.ts
 import {
-	RegistrationContainerProps,
-	RegistrationFormData,
-	RegistrationFormDataPatch,
-	Event,
-	ApiResponse,
-} from "./types/registration.types";
+  RegistrationContainerProps,
+  RegistrationFormData,
+  RegistrationFormDataPatch,
+  Event,
+  ApiResponse,
+} from './types/registration.types';
+
+// ---------------------------------------------------------------------------
+// Module-level helpers shared between the router-state and API-fetch prefill
+// paths so the logic stays in one place.
+// ---------------------------------------------------------------------------
+
+/** Convert yyyy-mm-dd → "MM / DD / YYYY" (format expected by the form). */
+const convertHouseholdDateFormat = (dateString: string): string => {
+  if (!dateString || dateString === '1900-01-01') return '';
+  try {
+    const [year, month, day] = dateString.split('-').map(Number);
+    if (
+      isNaN(year) ||
+      isNaN(month) ||
+      isNaN(day) ||
+      year < 1900 ||
+      year > 2100 ||
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > 31
+    ) {
+      return '';
+    }
+    return `${String(month).padStart(2, '0')} / ${String(day).padStart(2, '0')} / ${String(year)}`;
+  } catch {
+    return '';
+  }
+};
+
+/** Convert a household gender_id to the form value expected by HouseholdForm. */
+const getGenderForForm = (genderId: number | null): string => {
+  if (!genderId) return '';
+  const gender = getGenderFromId(genderId);
+  if (!gender) return '';
+  const map: Record<string, string> = {
+    male: 'male',
+    female: 'female',
+    other: 'other',
+    prefer_not_to_say: 'not_specify',
+  };
+  return map[gender] || '';
+};
 
 // Utility to sanitize user object
 function sanitizeUser(user: any): RegistrationFormData {
-	if (!user || typeof user !== "object") return { ...defaultUser };
-	return {
-		first_name: user.first_name || "",
-		middle_name: user.middle_name || "",
-		last_name: user.last_name || "",
-		suffix: user.suffix || "",
-		date_of_birth: user.date_of_birth || "",
-		gender: user.gender || "",
-		address_line_1: user.address_line_1 || "",
-		address_line_2: user.address_line_2 || "",
-		city: user.city || "",
-		state: user.state || "",
-		zip_code: user.zip_code || "",
-		phone: user.phone || "",
-		permission_to_text: user.permission_to_text || false,
-		email: user.email || "",
-		permission_to_email: user.permission_to_email || false,
-		seniors_in_household: user.seniors_in_household || 0,
-		adults_in_household: user.adults_in_household || 0,
-		children_in_household: user.children_in_household || 0,
-		license_plate: user.license_plate || "",
-		identification_code: user.identification_code || "",
-		id: user.id,
-		user_type: user.user_type,
-		created_at: user.created_at,
-		updated_at: user.updated_at,
-		credential_id: user.credential_id,
-		user_detail_id: user.user_detail_id,
-	};
+  if (!user || typeof user !== 'object') return { ...defaultUser };
+  return {
+    first_name: user.first_name || '',
+    middle_name: user.middle_name || '',
+    last_name: user.last_name || '',
+    suffix: user.suffix || '',
+    date_of_birth: user.date_of_birth || '',
+    gender: user.gender || '',
+    address_line_1: user.address_line_1 || '',
+    address_line_2: user.address_line_2 || '',
+    city: user.city || '',
+    state: user.state || '',
+    zip_code: user.zip_code || '',
+    phone: user.phone || '',
+    permission_to_text: user.permission_to_text || false,
+    email: user.email || '',
+    permission_to_email: user.permission_to_email || false,
+    seniors_in_household: user.seniors_in_household || 0,
+    adults_in_household: user.adults_in_household || 0,
+    children_in_household: user.children_in_household || 0,
+    license_plate: user.license_plate || '',
+    identification_code: user.identification_code || '',
+    id: user.id,
+    user_type: user.user_type,
+    created_at: user.created_at,
+    updated_at: user.updated_at,
+    credential_id: user.credential_id,
+    user_detail_id: user.user_detail_id,
+  };
 }
 
 const defaultUser: RegistrationFormData = {
-	first_name: "",
-	middle_name: "",
-	last_name: "",
-	suffix: "",
-	date_of_birth: "",
-	gender: "",
-	address_line_1: "",
-	address_line_2: "",
-	city: "",
-	state: "",
-	zip_code: "",
-	phone: "",
-	permission_to_text: false,
-	email: "",
-	permission_to_email: false,
-	seniors_in_household: 0,
-	adults_in_household: 0,
-	children_in_household: 0,
+  first_name: '',
+  middle_name: '',
+  last_name: '',
+  suffix: '',
+  date_of_birth: '',
+  gender: '',
+  address_line_1: '',
+  address_line_2: '',
+  city: '',
+  state: '',
+  zip_code: '',
+  phone: '',
+  permission_to_text: false,
+  email: '',
+  permission_to_email: false,
+  seniors_in_household: 0,
+  adults_in_household: 0,
+  children_in_household: 0,
 
-	identification_code: "",
+  identification_code: '',
 };
 
 /**
@@ -107,1000 +141,921 @@ const defaultUser: RegistrationFormData = {
  * Handles authentication, event fetching, user registration, and navigation
  */
 const RegistrationContainer: React.FC<RegistrationContainerProps> = () => {
-	const dispatch = useDispatch();
-	const navigate = useNavigate();
-	const location = useLocation();
-	const { eventDateId, eventSlotId } = useParams();
-	const [isLoading, setLoading] = useState<boolean>(false);
-	const [userToken, setUserToken] = useState<string | undefined>(undefined);
-	const [isError, setIsError] = useState<boolean>(false);
-	const [pageError, setPageError] = useState<boolean>(false);
-	const [errors, setErrors] = useState<string[]>([]);
-	const [disabled, setDisabled] = useState<boolean>(false);
-	const [showAuthModal, setShowAuthModal] = useState<boolean>(false);
-	const [householdMembers, setHouseholdMembers] = useState<any[]>([]);
-	const redirectTimeout = useRef<NodeJS.Timeout | null>(null);
-	const householdDataProcessedRef = useRef<boolean>(false);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { eventDateId, eventSlotId } = useParams();
+  const [isLoading, setLoading] = useState<boolean>(false);
+  const [userToken, setUserToken] = useState<string | undefined>(undefined);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [pageError, setPageError] = useState<boolean>(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [disabled, setDisabled] = useState<boolean>(false);
+  const [showAuthModal, setShowAuthModal] = useState<boolean>(false);
+  const [householdMembers, setHouseholdMembers] = useState<any[]>([]);
+  const redirectTimeout = useRef<NodeJS.Timeout | null>(null);
+  const householdDataProcessedRef = useRef<boolean>(false);
+  // Guards the API-based prefill (RSVP path) so it only runs once per navigation.
+  const householdApiFetchedRef = useRef<boolean>(false);
 
-	const event = useSelector(selectEvent);
-	// Don't initialize from Redux cache - always start fresh to avoid stale data from previous sessions
-	const [selectedEvent, setSelectedEvent] = useState<Event>({} as Event);
+  const householdsApiService = useMemo(() => new HouseholdsApiService(), []);
 
-	const currentUser = useSelector(selectUser);
-	const [user, setUser] = useState<RegistrationFormData | null>(currentUser);
-	const CLIENT_URL = config.CLIENT_URL;
+  const event = useSelector(selectEvent);
+  // Don't initialize from Redux cache - always start fresh to avoid stale data from previous sessions
+  const [selectedEvent, setSelectedEvent] = useState<Event>({} as Event);
 
-	const getEvent = useCallback(async (): Promise<void> => {
-		try {
-			setLoading(true);
-			const resp = await axios.get<{ event: Event; errors?: string[] }>(
-				API_URL.EVENT_DATE_DETAILS(eventDateId),
-			);
-			const { data } = resp;
-			if (data && data.event) {
-				const eventData = EventFormat(data.event, eventDateId);
-				dispatch(setCurrentEvent(eventData));
-				setSelectedEvent(eventData);
-				setLoading(false);
-			} else {
-				setPageError(true);
-				setErrors(data.errors || []);
-				setLoading(false);
-			}
-		} catch (e: any) {
-			console.error(e);
-			setIsError(true);
-			setLoading(false);
-			if (e.response) {
-				setPageError(true);
-				setErrors(e.response.data);
-			}
-		}
-	}, [eventDateId, dispatch]);
+  const currentUser = useSelector(selectUser);
+  const [user, setUser] = useState<RegistrationFormData | null>(currentUser);
+  const CLIENT_URL = config.CLIENT_URL;
 
-	// Fetch event data when eventDateId changes - this fixes the caching bug
-	// where stale event data from localStorage (redux-persist) was shown instead of
-	// fetching fresh data for the URL's event ID
-	useEffect(() => {
-		// Reset state when eventDateId changes
-		setIsError(false);
-		setPageError(false);
-		setErrors([]);
+  const getEvent = useCallback(async (): Promise<void> => {
+    try {
+      setLoading(true);
+      const resp = await axios.get<{ event: Event; errors?: string[] }>(
+        API_URL.EVENT_DATE_DETAILS(eventDateId),
+      );
+      const { data } = resp;
+      if (data && data.event) {
+        const eventData = EventFormat(data.event, eventDateId);
+        dispatch(setCurrentEvent(eventData));
+        setSelectedEvent(eventData);
+        setLoading(false);
+      } else {
+        setPageError(true);
+        setErrors(data.errors || []);
+        setLoading(false);
+      }
+    } catch (e: any) {
+      console.error(e);
+      setIsError(true);
+      setLoading(false);
+      if (e.response) {
+        setPageError(true);
+        setErrors(e.response.data);
+      }
+    }
+  }, [eventDateId, dispatch]);
 
-		// Always fetch fresh event data based on URL parameter
-		if (eventDateId) {
-			getEvent();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [eventDateId]);
+  // Fetch event data when eventDateId changes - this fixes the caching bug
+  // where stale event data from localStorage (redux-persist) was shown instead of
+  // fetching fresh data for the URL's event ID
+  useEffect(() => {
+    // Reset state when eventDateId changes
+    setIsError(false);
+    setPageError(false);
+    setErrors([]);
 
-	useEffect(() => {
-		const token = StorageService.getUserToken();
-		const userProfile = StorageService.getGuestUser();
-		setUserToken(token || (userProfile as any)?.token || undefined);
+    // Always fetch fresh event data based on URL parameter
+    if (eventDateId) {
+      getEvent();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventDateId]);
 
-		// Only proceed if we're not in an error state
-		if (!isError && !pageError) {
-			// Event fetching is now handled by the eventDateId useEffect above
+  useEffect(() => {
+    const token = StorageService.getUserToken();
+    const userProfile = StorageService.getGuestUser();
+    setUserToken(token || (userProfile as any)?.token || undefined);
 
-			// Handle user authentication and profile
-			// Check for both guest authentication (userToken) and Cognito authentication
-			const cognitoUser = StorageService.getCognitoUser();
-			const isCognitoSignedIn = StorageService.isLoggedInUser();
+    // Only proceed if we're not in an error state
+    if (!isError && !pageError) {
+      // Event fetching is now handled by the eventDateId useEffect above
 
-			// Check if user has guest authentication with valid token
-			const isGuestAuthenticated = StorageService.isGuestUser();
+      // Handle user authentication and profile
+      // Check for both guest authentication (userToken) and Cognito authentication
+      const cognitoUser = StorageService.getCognitoUser();
+      const isCognitoSignedIn = StorageService.isLoggedInUser();
 
-			const isUserAuthenticated =
-				token || isGuestAuthenticated || isCognitoSignedIn;
+      // Check if user has guest authentication with valid token
+      const isGuestAuthenticated = StorageService.isGuestUser();
 
-			if (!isUserAuthenticated) {
-				setShowAuthModal(true);
-			} else if (!user) {
-				if (StorageService.isCaseManager()) {
-					// Case managers register on behalf of others -- start with an empty form
-					setUser(
-						sanitizeUser({
-							first_name: "",
-							last_name: "",
-							email: "",
-							phone_number: "",
-							address: "",
-							city: "",
-							state: "",
-							zip_code: "",
-							adult_count: 1,
-							senior_count: 0,
-							child_count: 0,
-							permission_to_text: false,
-							permission_to_email: false,
-						}),
-					);
-				} else if (userProfile) {
-					// Guest user - use existing userProfile
-					try {
-						setUser(sanitizeUser(userProfile as any));
-					} catch (error) {
-						console.error("Error parsing userProfile:", error);
-					}
-				} else if (cognitoUser && isCognitoSignedIn) {
-					// Cognito user - create user object from cognitoUser data
-					try {
-						const cognitoUserObj = {
-							first_name: cognitoUser.name?.split(" ")[0] || "",
-							last_name:
-								cognitoUser.name
-									?.split(" ")
-									.slice(1)
-									.join(" ") || "",
-							email: cognitoUser.email || "",
-							phone_number: "",
-							address: "",
-							city: "",
-							state: "",
-							zip_code: "",
-							adult_count: 1,
-							senior_count: 0,
-							child_count: 0,
-							permission_to_text: false,
-							permission_to_email: true,
-						};
-						setUser(sanitizeUser(cognitoUserObj));
-					} catch (error) {
-						console.error("Error parsing cognitoUser:", error);
-					}
-				}
-			} else if (
-				user &&
-				location.state?.householdData &&
-				!householdDataProcessedRef.current &&
-				!StorageService.isCaseManager()
-			) {
-				// Prefill form with household data if available (only once)
-				try {
-					const householdData = location.state
-						.householdData as UsersMeResponse;
+      const isUserAuthenticated = token || isGuestAuthenticated || isCognitoSignedIn;
 
-					// Get primary member data for DOB and gender
-					const primaryMember =
-						householdData.members &&
-						householdData.members.length > 0
-							? householdData.members[0]
-							: null;
+      if (!isUserAuthenticated) {
+        setShowAuthModal(true);
+      } else if (!user) {
+        if (StorageService.isCaseManager()) {
+          // Case managers register on behalf of others -- start with an empty form
+          setUser(
+            sanitizeUser({
+              first_name: '',
+              last_name: '',
+              email: '',
+              phone_number: '',
+              address: '',
+              city: '',
+              state: '',
+              zip_code: '',
+              adult_count: 1,
+              senior_count: 0,
+              child_count: 0,
+              permission_to_text: false,
+              permission_to_email: false,
+            }),
+          );
+        } else if (userProfile) {
+          // Guest user - use existing userProfile
+          try {
+            setUser(sanitizeUser(userProfile as any));
+          } catch (error) {
+            console.error('Error parsing userProfile:', error);
+          }
+        } else if (cognitoUser && isCognitoSignedIn) {
+          // Cognito user - create user object from cognitoUser data
+          try {
+            const cognitoUserObj = {
+              first_name: cognitoUser.name?.split(' ')[0] || '',
+              last_name: cognitoUser.name?.split(' ').slice(1).join(' ') || '',
+              email: cognitoUser.email || '',
+              phone_number: '',
+              address: '',
+              city: '',
+              state: '',
+              zip_code: '',
+              adult_count: 1,
+              senior_count: 0,
+              child_count: 0,
+              permission_to_text: false,
+              permission_to_email: true,
+            };
+            setUser(sanitizeUser(cognitoUserObj));
+          } catch (error) {
+            console.error('Error parsing cognitoUser:', error);
+          }
+        }
+      } else if (
+        user &&
+        location.state?.householdData &&
+        !householdDataProcessedRef.current &&
+        !StorageService.isCaseManager()
+      ) {
+        // Prefill form with household data if available (only once)
+        try {
+          const householdData = location.state.householdData as UsersMeResponse;
 
-					// Convert date from yyyy-mm-dd to MM / DD / YYYY format for form
-					const convertDateFormat = (dateString: string): string => {
-						if (!dateString || dateString === "1900-01-01") {
-							return "";
-						}
-						try {
-							const [year, month, day] = dateString
-								.split("-")
-								.map(Number);
-							if (
-								isNaN(year) ||
-								isNaN(month) ||
-								isNaN(day) ||
-								year < 1900 ||
-								year > 2100 ||
-								month < 1 ||
-								month > 12 ||
-								day < 1 ||
-								day > 31
-							) {
-								return "";
-							}
-							const monthStr = String(month).padStart(2, "0");
-							const dayStr = String(day).padStart(2, "0");
-							const yearStr = String(year);
-							// Return in MM / DD / YYYY format (with spaces around slashes) for form
-							return `${monthStr} / ${dayStr} / ${yearStr}`;
-						} catch (error) {
-							return "";
-						}
-					};
+          // Get primary member data for DOB and gender
+          const primaryMember =
+            householdData.members && householdData.members.length > 0
+              ? householdData.members[0]
+              : null;
 
-					// Convert gender_id to form value (lowercase format expected by form)
-					const getGenderForForm = (
-						genderId: number | null,
-					): string => {
-						if (!genderId) return "";
-						const gender = getGenderFromId(genderId);
-						if (!gender) return "";
-						const genderMap: Record<string, string> = {
-							male: "male",
-							female: "female",
-							other: "other",
-							prefer_not_to_say: "not_specify",
-						};
-						return genderMap[gender] || "";
-					};
+          const prefilledUser = {
+            ...user,
+            // Prefill name from primary household member
+            first_name: primaryMember?.first_name || user.first_name,
+            last_name: primaryMember?.last_name || user.last_name,
+            middle_name: primaryMember?.middle_name || user.middle_name,
+            // Prefill address information
+            address_line_1: householdData.address_line_1 || user.address_line_1,
+            address_line_2: householdData.address_line_2 || user.address_line_2,
+            city: householdData.city || user.city,
+            state: householdData.state || user.state,
+            zip_code: householdData.zip_code || user.zip_code,
+            phone: householdData.phone || user.phone,
+            email: householdData.email || user.email,
+            // Prefill contact preferences
+            permission_to_text: householdData.permission_to_text ?? user.permission_to_text,
+            permission_to_email: householdData.permission_to_email ?? user.permission_to_email,
+            // Prefill date_of_birth, gender, and suffix from primary member
+            date_of_birth: primaryMember
+              ? convertHouseholdDateFormat(primaryMember.date_of_birth || '')
+              : user.date_of_birth || '',
+            gender: primaryMember
+              ? getGenderForForm(primaryMember.gender_id || null)
+              : user.gender || '',
+            suffix: primaryMember ? getSuffixFromId(primaryMember.suffix_id) : user.suffix || '',
+            // Prefill household member counts (excludes HOH from the correct age bucket)
+            ...((): Pick<
+              RegistrationFormData,
+              'adults_in_household' | 'children_in_household' | 'seniors_in_household'
+            > => {
+              const counts = getAdditionalMemberCounts(
+                householdData.counts || {},
+                primaryMember?.date_of_birth,
+              );
+              return {
+                seniors_in_household: counts.seniors,
+                adults_in_household: counts.adults,
+                children_in_household: counts.children,
+              };
+            })(),
+            // Prefill household name if available
+            identification_code: householdData.identification_code || user.identification_code,
+          };
+          setUser(prefilledUser);
+          // Store household members for count validation
+          if (householdData.members && householdData.members.length > 0) {
+            setHouseholdMembers(householdData.members);
+          }
+          householdDataProcessedRef.current = true; // Mark as processed
+        } catch (error) {
+          console.error('Error prefilling with household data:', error);
+        }
+      }
+    }
 
-					const prefilledUser = {
-						...user,
-						// Prefill address information
-						address_line_1:
-							householdData.address_line_1 || user.address_line_1,
-						address_line_2:
-							householdData.address_line_2 || user.address_line_2,
-						city: householdData.city || user.city,
-						state: householdData.state || user.state,
-						zip_code: householdData.zip_code || user.zip_code,
-						phone: householdData.phone || user.phone,
-						email: householdData.email || user.email,
-						// Prefill contact preferences
-						permission_to_text:
-							householdData.permission_to_text ??
-							user.permission_to_text,
-						permission_to_email:
-							householdData.permission_to_email ??
-							user.permission_to_email,
-						// Prefill date_of_birth, gender, and suffix from primary member
-						date_of_birth: primaryMember
-							? convertDateFormat(
-									primaryMember.date_of_birth || "",
-								)
-							: user.date_of_birth || "",
-						gender: primaryMember
-							? getGenderForForm(primaryMember.gender_id || null)
-							: user.gender || "",
-						suffix: primaryMember
-							? getSuffixFromId(primaryMember.suffix_id)
-							: user.suffix || "",
-						// Prefill household member counts (excludes HOH from the correct age bucket)
-						...((): Pick<
-							RegistrationFormData,
-							| "adults_in_household"
-							| "children_in_household"
-							| "seniors_in_household"
-						> => {
-							const counts = getAdditionalMemberCounts(
-								householdData.counts || {},
-								primaryMember?.date_of_birth,
-							);
-							return {
-								seniors_in_household: counts.seniors,
-								adults_in_household: counts.adults,
-								children_in_household: counts.children,
-							};
-						})(),
-						// Prefill household name if available
-						identification_code:
-							householdData.identification_code ||
-							user.identification_code,
-					};
-					setUser(prefilledUser);
-					// Store household members for count validation
-					if (
-						householdData.members &&
-						householdData.members.length > 0
-					) {
-						setHouseholdMembers(householdData.members);
-					}
-					householdDataProcessedRef.current = true; // Mark as processed
-				} catch (error) {
-					console.error(
-						"Error prefilling with household data:",
-						error,
-					);
-				}
-			}
-		}
+    // Only redirect if user is still not set after 2 seconds (increased from 1)
+    if (!showAuthModal && !user && !isLoading) {
+      if (redirectTimeout.current) clearTimeout(redirectTimeout.current);
+      redirectTimeout.current = setTimeout(() => {
+        if (!user) {
+          setErrors(['Unable to load user profile. Please try again or contact support.']);
+          setPageError(true);
+        }
+      }, 2000);
+    } else {
+      if (redirectTimeout.current) clearTimeout(redirectTimeout.current);
+    }
+  }, [
+    isError,
+    pageError,
+    selectedEvent,
+    user,
+    userToken,
+    showAuthModal,
+    isLoading,
+    eventDateId,
+    navigate,
+    getEvent,
+    location.state,
+  ]);
 
-		// Only redirect if user is still not set after 2 seconds (increased from 1)
-		if (!showAuthModal && !user && !isLoading) {
-			if (redirectTimeout.current) clearTimeout(redirectTimeout.current);
-			redirectTimeout.current = setTimeout(() => {
-				if (!user) {
-					setErrors([
-						"Unable to load user profile. Please try again or contact support.",
-					]);
-					setPageError(true);
-				}
-			}, 2000);
-		} else {
-			if (redirectTimeout.current) clearTimeout(redirectTimeout.current);
-		}
-	}, [
-		isError,
-		pageError,
-		selectedEvent,
-		user,
-		userToken,
-		showAuthModal,
-		isLoading,
-		eventDateId,
-		navigate,
-		getEvent,
-		location.state,
-	]);
+  // Reset household data processing flags when location changes
+  useEffect(() => {
+    householdDataProcessedRef.current = false;
+    householdApiFetchedRef.current = false;
+  }, [location.state]);
 
-	// Reset household data processing flag when location changes
-	useEffect(() => {
-		householdDataProcessedRef.current = false;
-	}, [location.state]);
+  /**
+   * RSVP path prefill: Cognito users arriving without householdData in router
+   * state (i.e. RSVP events that skip the timeslot modal) still deserve full
+   * household prefill.  Fetch /users/me once the user object is initialised
+   * and apply the same mapping used by the router-state path above.
+   */
+  useEffect(() => {
+    const isCognitoSignedIn = StorageService.isLoggedInUser();
+    const hasRouterHouseholdData = Boolean(location.state?.householdData);
 
-	const handleAuthLogin = (): void => {
-		const token = StorageService.getUserToken();
-		const userProfile = StorageService.getGuestUser();
-		if (token && userProfile) {
-			setUserToken(token || undefined);
-			try {
-				setUser(sanitizeUser(userProfile as any));
-			} catch (error) {
-				console.error("Error parsing userProfile:", error);
-			}
-			setShowAuthModal(false);
-		}
-	};
+    if (
+      !user ||
+      !isCognitoSignedIn ||
+      StorageService.isCaseManager() ||
+      hasRouterHouseholdData ||
+      householdApiFetchedRef.current
+    ) {
+      return;
+    }
 
-	const getReservationText = (): string => {
-		return location.state
-			? `at ${event.agencyName} on ${location.state.event_date} from ${location.state.event_slot.start_time} - ${location.state.event_slot.end_time}. For more information, including a reservation QR code,`
-			: "";
-	};
+    householdApiFetchedRef.current = true;
 
-	const getCodeURL = (identification_code: string): string => {
-		return `Your QRCode for the Reservation ${CLIENT_URL}qrcode/${identification_code}/${eventDateId}${
-			eventSlotId ? "/" + eventSlotId : ""
-		}`;
-	};
+    householdsApiService
+      .getUsersMe()
+      .then((householdData) => {
+        const primaryMember =
+          householdData.members && householdData.members.length > 0
+            ? householdData.members[0]
+            : null;
 
-	// Check if error message indicates "already registered"
-	const isAlreadyRegisteredError = (errorData: any): boolean => {
-		if (!errorData || typeof errorData !== "object") {
-			return false;
-		}
+        const counts = getAdditionalMemberCounts(
+          householdData.counts || {},
+          primaryMember?.date_of_birth,
+        );
 
-		const errorText = JSON.stringify(errorData).toLowerCase();
-		const alreadyRegisteredKeywords = [
-			"already registered",
-			"already exist",
-			"user already",
-			"duplicate registration",
-		];
+        setUser((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            first_name: primaryMember?.first_name || prev.first_name,
+            last_name: primaryMember?.last_name || prev.last_name,
+            middle_name: primaryMember?.middle_name || prev.middle_name,
+            suffix: primaryMember ? getSuffixFromId(primaryMember.suffix_id) : prev.suffix,
+            date_of_birth: primaryMember
+              ? convertHouseholdDateFormat(primaryMember.date_of_birth || '')
+              : prev.date_of_birth,
+            gender: primaryMember ? getGenderForForm(primaryMember.gender_id || null) : prev.gender,
+            address_line_1: householdData.address_line_1 || prev.address_line_1,
+            address_line_2: householdData.address_line_2 || prev.address_line_2,
+            city: householdData.city || prev.city,
+            state: householdData.state || prev.state,
+            zip_code: householdData.zip_code || prev.zip_code,
+            phone: householdData.phone || prev.phone,
+            email: householdData.email || prev.email,
+            permission_to_text: householdData.permission_to_text ?? prev.permission_to_text,
+            permission_to_email: householdData.permission_to_email ?? prev.permission_to_email,
+            seniors_in_household: counts.seniors,
+            adults_in_household: counts.adults,
+            children_in_household: counts.children,
+            identification_code: householdData.identification_code || prev.identification_code,
+          };
+        });
 
-		return alreadyRegisteredKeywords.some((keyword) =>
-			errorText.includes(keyword),
-		);
-	};
+        if (householdData.members && householdData.members.length > 0) {
+          setHouseholdMembers(householdData.members);
+        }
+      })
+      .catch((error) => {
+        console.error('Error fetching household data for RSVP prefill:', error);
+      });
+  }, [user, location.state, householdsApiService]);
 
-	const formatErrorMessage = (message: string): string => {
-		// Make error messages more user-friendly
-		const errorMappings: Record<string, string> = {
-			"is at capacity":
-				"This time slot is at capacity. Please select a different time.",
-			"is required": "This field is required.",
-			"is invalid": "This field contains invalid data.",
-			"not found": "The requested resource was not found.",
-			"already exists": "This record already exists.",
-			"permission denied":
-				"You do not have permission to perform this action.",
-			unauthorized: "Please log in to continue.",
-			forbidden: "Access denied.",
-			"not available": "This option is not available.",
-			expired: "This session has expired. Please log in again.",
-			"invalid token": "Your session has expired. Please log in again.",
-			"network error":
-				"Network error. Please check your connection and try again.",
-			timeout: "Request timed out. Please try again.",
-			"server error": "Server error. Please try again later.",
-		};
+  const handleAuthLogin = (): void => {
+    const token = StorageService.getUserToken();
+    const userProfile = StorageService.getGuestUser();
+    if (token && userProfile) {
+      setUserToken(token || undefined);
+      try {
+        setUser(sanitizeUser(userProfile as any));
+      } catch (error) {
+        console.error('Error parsing userProfile:', error);
+      }
+      setShowAuthModal(false);
+    }
+  };
 
-		// Check for exact matches first
-		if (errorMappings[message.toLowerCase()]) {
-			return errorMappings[message.toLowerCase()];
-		}
+  const getReservationText = (): string => {
+    return location.state
+      ? `at ${event.agencyName} on ${location.state.event_date} from ${location.state.event_slot.start_time} - ${location.state.event_slot.end_time}. For more information, including a reservation QR code,`
+      : '';
+  };
 
-		// Check for partial matches
-		for (const [key, value] of Object.entries(errorMappings)) {
-			if (message.toLowerCase().includes(key)) {
-				return value;
-			}
-		}
+  const getCodeURL = (identification_code: string): string => {
+    return `Your QRCode for the Reservation ${CLIENT_URL}qrcode/${identification_code}/${eventDateId}${
+      eventSlotId ? '/' + eventSlotId : ''
+    }`;
+  };
 
-		// Return the original message if no mapping found
-		return message;
-	};
+  // Check if error message indicates "already registered"
+  const isAlreadyRegisteredError = (errorData: any): boolean => {
+    if (!errorData || typeof errorData !== 'object') {
+      return false;
+    }
 
-	const notify = (msg: any, error: string): void => {
-		let formatted_msg = "Something Went Wrong";
+    const errorText = JSON.stringify(errorData).toLowerCase();
+    const alreadyRegisteredKeywords = [
+      'already registered',
+      'already exist',
+      'user already',
+      'duplicate registration',
+    ];
 
-		// Extract error messages from different possible fields
-		if (msg && typeof msg === "object") {
-			// Check for specific error fields
-			const errorFields = [
-				"user_id",
-				"event_date_id",
-				"event_slot_id",
-				"reservation",
-			];
-			for (const field of errorFields) {
-				if (
-					msg[field] &&
-					Array.isArray(msg[field]) &&
-					msg[field].length > 0
-				) {
-					formatted_msg = formatErrorMessage(msg[field][0]);
-					break;
-				}
-			}
+    return alreadyRegisteredKeywords.some((keyword) => errorText.includes(keyword));
+  };
 
-			// If no specific field found, try to get the first error message from any field
-			if (formatted_msg === "Something Went Wrong") {
-				const firstError = Object.values(msg).find(
-					(value): value is string[] =>
-						Array.isArray(value) && value.length > 0,
-				);
-				if (firstError && firstError.length > 0) {
-					formatted_msg = formatErrorMessage(firstError[0]);
-				}
-			}
-		}
+  const formatErrorMessage = (message: string): string => {
+    // Make error messages more user-friendly
+    const errorMappings: Record<string, string> = {
+      'is at capacity': 'This time slot is at capacity. Please select a different time.',
+      'is required': 'This field is required.',
+      'is invalid': 'This field contains invalid data.',
+      'not found': 'The requested resource was not found.',
+      'already exists': 'This record already exists.',
+      'permission denied': 'You do not have permission to perform this action.',
+      unauthorized: 'Please log in to continue.',
+      forbidden: 'Access denied.',
+      'not available': 'This option is not available.',
+      expired: 'This session has expired. Please log in again.',
+      'invalid token': 'Your session has expired. Please log in again.',
+      'network error': 'Network error. Please check your connection and try again.',
+      timeout: 'Request timed out. Please try again.',
+      'server error': 'Server error. Please try again later.',
+    };
 
-		showToast(formatted_msg, error);
-	};
-	const send_sms = async (user: RegistrationFormData): Promise<void> => {
-		const { TWILIO_SMS } = API_URL;
-		let to_phone_number = user["phone"];
-		let identification_code = user["identification_code"];
-		if (identification_code) {
-			let message = `You have successfully registered for an event, ${getReservationText()} Your confirmation code is ${identification_code.toUpperCase()}.
+    // Check for exact matches first
+    if (errorMappings[message.toLowerCase()]) {
+      return errorMappings[message.toLowerCase()];
+    }
+
+    // Check for partial matches
+    for (const [key, value] of Object.entries(errorMappings)) {
+      if (message.toLowerCase().includes(key)) {
+        return value;
+      }
+    }
+
+    // Return the original message if no mapping found
+    return message;
+  };
+
+  const notify = (msg: any, error: string): void => {
+    let formatted_msg = 'Something Went Wrong';
+
+    // Extract error messages from different possible fields
+    if (msg && typeof msg === 'object') {
+      // Check for specific error fields
+      const errorFields = ['user_id', 'event_date_id', 'event_slot_id', 'reservation'];
+      for (const field of errorFields) {
+        if (msg[field] && Array.isArray(msg[field]) && msg[field].length > 0) {
+          formatted_msg = formatErrorMessage(msg[field][0]);
+          break;
+        }
+      }
+
+      // If no specific field found, try to get the first error message from any field
+      if (formatted_msg === 'Something Went Wrong') {
+        const firstError = Object.values(msg).find(
+          (value): value is string[] => Array.isArray(value) && value.length > 0,
+        );
+        if (firstError && firstError.length > 0) {
+          formatted_msg = formatErrorMessage(firstError[0]);
+        }
+      }
+    }
+
+    showToast(formatted_msg, error);
+  };
+  const send_sms = async (user: RegistrationFormData): Promise<void> => {
+    const { TWILIO_SMS } = API_URL;
+    const to_phone_number = user['phone'];
+    const identification_code = user['identification_code'];
+    if (identification_code) {
+      const message = `You have successfully registered for an event, ${getReservationText()} Your confirmation code is ${identification_code.toUpperCase()}.
     ${getCodeURL(identification_code)}`;
-			let search_zip = StorageService.getItem<string>("search_zip");
-			if (search_zip) {
-				setLoading(true);
-				let foodBankUri = API_URL.FOODBANK_LIST;
-				try {
-					const resp = await axios.get(foodBankUri, {
-						params: { zip_code: search_zip },
-					});
-					const { data } = resp;
-					let from_phone_number =
-						data.foodbanks[0].twilio_phone_number;
-					try {
-						await axios.post(TWILIO_SMS, {
-							from_phone_number,
-							to_phone_number,
-							message,
-						});
-					} catch (e) {
-						console.warn(e);
-					}
-					setLoading(false);
-				} catch (err) {
-					setLoading(false);
-				}
-			}
-		}
-	};
+      const search_zip = StorageService.getItem<string>('search_zip');
+      if (search_zip) {
+        setLoading(true);
+        const foodBankUri = API_URL.FOODBANK_LIST;
+        try {
+          const resp = await axios.get(foodBankUri, {
+            params: { zip_code: search_zip },
+          });
+          const { data } = resp;
+          const from_phone_number = data.foodbanks[0].twilio_phone_number;
+          try {
+            await axios.post(TWILIO_SMS, {
+              from_phone_number,
+              to_phone_number,
+              message,
+            });
+          } catch (e) {
+            console.warn(e);
+          }
+          setLoading(false);
+        } catch (err) {
+          setLoading(false);
+        }
+      }
+    }
+  };
 
-	// Helper function to determine user type
-	const determineUserType = (): "guest" | "cognito" | "case_manager" => {
-		if (StorageService.isCaseManager()) {
-			return "case_manager";
-		}
-		if (StorageService.isLoggedInUser()) {
-			return "cognito";
-		}
-		return "guest";
-	};
+  // Helper function to determine user type
+  const determineUserType = (): 'guest' | 'cognito' | 'case_manager' => {
+    if (StorageService.isCaseManager()) {
+      return 'case_manager';
+    }
+    if (StorageService.isLoggedInUser()) {
+      return 'cognito';
+    }
+    return 'guest';
+  };
 
-	// Helper function to convert registration gender format to household format
-	const normalizeGenderToHouseholdFormat = (
-		gender: string,
-	): "male" | "female" | "other" | "prefer_not_to_say" => {
-		const normalized = gender.toLowerCase().trim();
-		if (normalized === "male") return "male";
-		if (normalized === "female") return "female";
-		if (normalized === "other") return "other";
-		if (
-			normalized === "prefer not to say" ||
-			normalized === "prefer_not_to_say"
-		)
-			return "prefer_not_to_say";
-		return "prefer_not_to_say";
-	};
+  // Helper function to convert registration gender format to household format
+  const normalizeGenderToHouseholdFormat = (
+    gender: string,
+  ): 'male' | 'female' | 'other' | 'prefer_not_to_say' => {
+    const normalized = gender.toLowerCase().trim();
+    if (normalized === 'male') return 'male';
+    if (normalized === 'female') return 'female';
+    if (normalized === 'other') return 'other';
+    if (normalized === 'prefer not to say' || normalized === 'prefer_not_to_say')
+      return 'prefer_not_to_say';
+    return 'prefer_not_to_say';
+  };
 
-	// Helper function to map registration data to household structure
-	const mapRegistrationToHousehold = (
-		registrationData: RegistrationFormData,
-		currentHousehold: UsersMeResponse,
-	): UpdateHouseholdApiRequest => {
-		// Exclude updated_at, language_id, preferred_language (API expects language_id only, not code)
-		const {
-			updated_at,
-			language_id: _currentLangId,
-			preferred_language: _omitLangCode,
-			...currentHouseholdWithoutTimestamp
-		} = currentHousehold;
+  // Helper function to map registration data to household structure
+  const mapRegistrationToHousehold = (
+    registrationData: RegistrationFormData,
+    currentHousehold: UsersMeResponse,
+  ): UpdateHouseholdApiRequest => {
+    // Exclude updated_at, language_id, preferred_language (API expects language_id only, not code)
+    const {
+      updated_at,
+      language_id: _currentLangId,
+      preferred_language: _omitLangCode,
+      ...currentHouseholdWithoutTimestamp
+    } = currentHousehold;
 
-		// Convert registration gender to gender_id if provided
-		let genderId: number | null = null;
-		if (registrationData.gender) {
-			const normalizedGender = normalizeGenderToHouseholdFormat(
-				registrationData.gender,
-			);
-			genderId = getGenderId(normalizedGender);
-		}
+    // Convert registration gender to gender_id if provided
+    let genderId: number | null = null;
+    if (registrationData.gender) {
+      const normalizedGender = normalizeGenderToHouseholdFormat(registrationData.gender);
+      genderId = getGenderId(normalizedGender);
+    }
 
-		// Convert registration suffix to suffix_id if provided
-		const suffixId: number | null = registrationData.suffix
-			? getSuffixId(registrationData.suffix) || null
-			: null;
+    // Convert registration suffix to suffix_id if provided
+    const suffixId: number | null = registrationData.suffix
+      ? getSuffixId(registrationData.suffix) || null
+      : null;
 
-		// Update the primary member (members[0]) with all registration data
-		const updatedMembers = currentHousehold.members.map((member, index) => {
-			// For the primary member (index 0), update with registration data
-			if (index === 0) {
-				return {
-					...member,
-					first_name:
-						registrationData.first_name || member.first_name,
-					last_name: registrationData.last_name || member.last_name,
-					middle_name:
-						registrationData.middle_name ||
-						member.middle_name ||
-						null,
-					date_of_birth:
-						registrationData.date_of_birth || member.date_of_birth,
-					gender_id:
-						genderId !== null
-							? genderId
-							: member.gender_id
-								? Number(member.gender_id)
-								: null,
-					suffix_id:
-						suffixId !== null
-							? suffixId
-							: member.suffix_id
-								? Number(member.suffix_id)
-								: null,
-				};
-			}
-			// For other members, preserve existing data with proper typing
-			return {
-				...member,
-				gender_id: member.gender_id ? Number(member.gender_id) : null,
-				suffix_id: member.suffix_id ? Number(member.suffix_id) : null,
-			};
-		});
+    // Update the primary member (members[0]) with all registration data
+    const updatedMembers = currentHousehold.members.map((member, index) => {
+      // For the primary member (index 0), update with registration data
+      if (index === 0) {
+        return {
+          ...member,
+          first_name: registrationData.first_name || member.first_name,
+          last_name: registrationData.last_name || member.last_name,
+          middle_name: registrationData.middle_name || member.middle_name || null,
+          date_of_birth: registrationData.date_of_birth || member.date_of_birth,
+          gender_id:
+            genderId !== null ? genderId : member.gender_id ? Number(member.gender_id) : null,
+          suffix_id:
+            suffixId !== null ? suffixId : member.suffix_id ? Number(member.suffix_id) : null,
+        };
+      }
+      // For other members, preserve existing data with proper typing
+      return {
+        ...member,
+        gender_id: member.gender_id ? Number(member.gender_id) : null,
+        suffix_id: member.suffix_id ? Number(member.suffix_id) : null,
+      };
+    });
 
-		const langCode =
-			registrationData.preferred_language ||
-			currentHousehold.preferred_language ||
-			"en";
-		const languageOption = getLanguageOptionByCode(langCode);
-		const languageId =
-			languageOption?.id ??
-			(_currentLangId !== undefined && _currentLangId !== null
-				? _currentLangId
-				: undefined);
+    const langCode =
+      registrationData.preferred_language || currentHousehold.preferred_language || 'en';
+    const languageOption = getLanguageOptionByCode(langCode);
+    const languageId =
+      languageOption?.id ??
+      (_currentLangId !== undefined && _currentLangId !== null ? _currentLangId : undefined);
 
-		const payload = {
-			// Preserve existing household structure (excluding updated_at, language_id)
-			...currentHouseholdWithoutTimestamp,
+    const payload = {
+      // Preserve existing household structure (excluding updated_at, language_id)
+      ...currentHouseholdWithoutTimestamp,
 
-			// Update fields from registration
-			address_line_1: registrationData.address_line_1 || null,
-			address_line_2: registrationData.address_line_2 || null,
-			city: registrationData.city || null,
-			state: registrationData.state || null,
-			zip_code: registrationData.zip_code || null,
-			phone: registrationData.phone
-				? normalizePhoneInput(registrationData.phone)
-				: null,
-			email: registrationData.email || null,
+      // Update fields from registration
+      address_line_1: registrationData.address_line_1 || null,
+      address_line_2: registrationData.address_line_2 || null,
+      city: registrationData.city || null,
+      state: registrationData.state || null,
+      zip_code: registrationData.zip_code || null,
+      phone: registrationData.phone ? normalizePhoneInput(registrationData.phone) : null,
+      email: registrationData.email || null,
 
-			// Update contact preferences
-			permission_to_text: registrationData.permission_to_text ?? null,
-			permission_to_email: registrationData.permission_to_email ?? null,
+      // Update contact preferences
+      permission_to_text: registrationData.permission_to_text ?? null,
+      permission_to_email: registrationData.permission_to_email ?? null,
 
-			counts: {
-				seniors: registrationData.seniors_in_household || 0,
-				adults: registrationData.adults_in_household || 0,
-				children: registrationData.children_in_household || 0,
-				total:
-					(registrationData.seniors_in_household || 0) +
-					(registrationData.adults_in_household || 0) +
-					(registrationData.children_in_household || 0),
-			},
+      counts: {
+        seniors: registrationData.seniors_in_household || 0,
+        adults: registrationData.adults_in_household || 0,
+        children: registrationData.children_in_household || 0,
+        total:
+          (registrationData.seniors_in_household || 0) +
+          (registrationData.adults_in_household || 0) +
+          (registrationData.children_in_household || 0),
+      },
 
-			// Update members array with all updates
-			members: updatedMembers,
+      // Update members array with all updates
+      members: updatedMembers,
 
-			// Send language_id only (API expects id, not preferred_language code)
-			...(languageId !== undefined && { language_id: languageId }),
-		};
+      // Send language_id only (API expects id, not preferred_language code)
+      ...(languageId !== undefined && { language_id: languageId }),
+    };
 
-		return payload;
-	};
+    return payload;
+  };
 
-	// Helper function to handle Cognito user update
-	const updateCognitoUser = async (
-		user: RegistrationFormData,
-	): Promise<void> => {
-		const cognitoToken = getCognitoToken();
-		if (!cognitoToken) {
-			throw new Error("No Cognito token found. Please sign in again.");
-		}
+  // Helper function to handle Cognito user update
+  const updateCognitoUser = async (user: RegistrationFormData): Promise<void> => {
+    const cognitoToken = getCognitoToken();
+    if (!cognitoToken) {
+      throw new Error('No Cognito token found. Please sign in again.');
+    }
 
-		try {
-			// Create HouseholdsApiService instance with Cognito token
-			const householdsApiService = new HouseholdsApiService();
+    try {
+      // Create HouseholdsApiService instance with Cognito token
+      const householdsApiService = new HouseholdsApiService();
 
-			// Get current household data from /me endpoint
-			const householdData = await householdsApiService.getUsersMe();
+      // Get current household data from /me endpoint
+      const householdData = await householdsApiService.getUsersMe();
 
-			// Ensure we have members data
-			if (!householdData.members || householdData.members.length === 0) {
-				throw new Error(
-					"No household members found. Please contact support.",
-				);
-			}
+      // Ensure we have members data
+      if (!householdData.members || householdData.members.length === 0) {
+        throw new Error('No household members found. Please contact support.');
+      }
 
-			// Map registration data to household structure
-			const updateData = mapRegistrationToHousehold(user, householdData);
+      // Map registration data to household structure
+      const updateData = mapRegistrationToHousehold(user, householdData);
 
-			// Update household using primary member ID
-			await householdsApiService.updateHousehold(
-				parseInt(householdData.members[0].user_id || "0", 10),
-				updateData,
-			);
-		} catch (error: any) {
-			// Handle authentication errors specifically
-			if (
-				handleAuthError(error, {
-					userType: "cognito",
-					redirectPath: "/login",
-					showToast,
-				})
-			) {
-				// Auth error was handled, re-throw to stop registration flow
-				throw error;
-			}
-			// Re-throw other errors to be handled by the main error handler
-			throw error;
-		}
-	};
+      // Update household using primary member ID
+      await householdsApiService.updateHousehold(
+        parseInt(householdData.members[0].user_id || '0', 10),
+        updateData,
+      );
+    } catch (error: any) {
+      // Handle authentication errors specifically
+      if (
+        handleAuthError(error, {
+          userType: 'cognito',
+          redirectPath: '/login',
+          showToast,
+        })
+      ) {
+        // Auth error was handled, re-throw to stop registration flow
+        throw error;
+      }
+      // Re-throw other errors to be handled by the main error handler
+      throw error;
+    }
+  };
 
-	// Helper function to handle errors gracefully
-	const handleRegistrationError = (
-		error: any,
-		userType: "guest" | "cognito" | "case_manager",
-	) => {
-		console.error(`${userType} registration error:`, error);
+  // Helper function to handle errors gracefully
+  const handleRegistrationError = (error: any, userType: 'guest' | 'cognito' | 'case_manager') => {
+    console.error(`${userType} registration error:`, error);
 
-		// Reset loading state to enable the Register button
-		setDisabled(false);
+    // Reset loading state to enable the Register button
+    setDisabled(false);
 
-		let errorMessage = "Registration failed. Please try again.";
-		let shouldRedirect = false;
-		let redirectPath = "";
+    let errorMessage = 'Registration failed. Please try again.';
+    let shouldRedirect = false;
+    let redirectPath = '';
 
-		if (userType === "cognito") {
-			if (error.message?.includes("token")) {
-				errorMessage =
-					"Your session has expired. Please sign in again.";
-				shouldRedirect = true;
-				redirectPath = "/login";
-			} else if (error.response?.status === 404) {
-				errorMessage = "Household not found. Please contact support.";
-				shouldRedirect = true;
-				redirectPath = "/";
-			} else if (error.response?.status >= 500) {
-				errorMessage = "Server error. Please try again later.";
-			}
-		} else {
-			if (error.response?.status === 401) {
-				errorMessage = "Guest session expired. Please start over.";
-				shouldRedirect = true;
-				redirectPath = "/";
-			}
-		}
+    if (userType === 'cognito') {
+      if (error.message?.includes('token')) {
+        errorMessage = 'Your session has expired. Please sign in again.';
+        shouldRedirect = true;
+        redirectPath = '/login';
+      } else if (error.response?.status === 404) {
+        errorMessage = 'Household not found. Please contact support.';
+        shouldRedirect = true;
+        redirectPath = '/';
+      } else if (error.response?.status >= 500) {
+        errorMessage = 'Server error. Please try again later.';
+      }
+    } else {
+      if (error.response?.status === 401) {
+        errorMessage = 'Guest session expired. Please start over.';
+        shouldRedirect = true;
+        redirectPath = '/';
+      }
+    }
 
-		showToast(errorMessage, "error");
+    showToast(errorMessage, 'error');
 
-		if (shouldRedirect) {
-			setTimeout(() => {
-				navigate(redirectPath);
-			}, 2000);
-		}
-	};
+    if (shouldRedirect) {
+      setTimeout(() => {
+        navigate(redirectPath);
+      }, 2000);
+    }
+  };
 
-	const register = async (
-		user: RegistrationFormData,
-		event: Event,
-	): Promise<void> => {
-		setDisabled(!disabled);
-		const event_date_id = parseInt(eventDateId || "0", 10);
-		const event_slot_id = parseInt(eventSlotId || "0", 10);
-		const { GUEST_USER, CREATE_RESERVATION } = API_URL;
-		let updatedUser = user;
+  const register = async (user: RegistrationFormData, event: Event): Promise<void> => {
+    setDisabled(!disabled);
+    const event_date_id = parseInt(eventDateId || '0', 10);
+    const event_slot_id = parseInt(eventSlotId || '0', 10);
+    const { GUEST_USER, CREATE_RESERVATION } = API_URL;
+    let updatedUser = user;
 
-		// Determine user type (guest vs cognito)
-		const userType = determineUserType();
+    // Determine user type (guest vs cognito)
+    const userType = determineUserType();
 
-		try {
-			if (userType === "case_manager") {
-				// Case manager flow: skip profile update; backend creates the registrant
-			} else if (userType === "guest") {
-				// Existing guest flow
-				// Get identification_code from stored user profile
-				const userProfile = StorageService.getGuestUser();
-				if (userProfile) {
-					try {
-						const userProfileData = userProfile as any;
-						if (
-							userProfileData.user &&
-							userProfileData.user.identification_code
-						) {
-							updatedUser = {
-								...user,
-								identification_code:
-									userProfileData.user.identification_code,
-							};
-						}
-					} catch (e) {
-						console.error("Error parsing user profile:", e);
-					}
-				}
+    try {
+      if (userType === 'case_manager') {
+        // Case manager flow: skip profile update; backend creates the registrant
+      } else if (userType === 'guest') {
+        // Existing guest flow
+        // Get identification_code from stored user profile
+        const userProfile = StorageService.getGuestUser();
+        if (userProfile) {
+          try {
+            const userProfileData = userProfile as any;
+            if (userProfileData.user && userProfileData.user.identification_code) {
+              updatedUser = {
+                ...user,
+                identification_code: userProfileData.user.identification_code,
+              };
+            }
+          } catch (e) {
+            console.error('Error parsing user profile:', e);
+          }
+        }
 
-				const { preferred_language: _omitLang, ...cleanUser } =
-					updatedUser;
-				const guestPayload = {
-					...cleanUser,
-					phone: updatedUser.phone
-						? normalizePhoneInput(updatedUser.phone)
-						: "",
-				};
-				const userResp = await axios.patch<
-					ApiResponse<RegistrationFormDataPatch>
-				>(GUEST_USER, guestPayload, {
-					headers: { "X-Guest-Token": `${userToken}` },
-				});
-				// Use the response data, which should include identification_code
-				// Merge response data with existing user data to maintain all required fields
-				updatedUser = { ...updatedUser, ...(userResp.data.data || {}) };
-			} else {
-				// New cognito flow
-				await updateCognitoUser(user);
-			}
-		} catch (e: any) {
-			// Handle authentication errors specifically
-			if (
-				handleAuthError(e, {
-					userType:
-						userType === "case_manager" ? "cognito" : userType,
-					redirectPath:
-						userType === "cognito" || userType === "case_manager"
-							? "/login"
-							: "/",
-					showToast,
-				})
-			) {
-				// Auth error was handled, exit early
-				return;
-			}
-			// Handle other errors with existing error handler
-			handleRegistrationError(e, userType);
-			return; // Exit early on error
-		}
-		try {
-			// Prepare headers based on user type
-			const headers: any =
-				userType === "guest"
-					? { "X-Guest-Token": `${userToken}` }
-					: { Authorization: `Bearer ${getCognitoToken()}` };
+        const { preferred_language: _omitLang, ...cleanUser } = updatedUser;
+        const guestPayload = {
+          ...cleanUser,
+          phone: updatedUser.phone ? normalizePhoneInput(updatedUser.phone) : '',
+        };
+        const userResp = await axios.patch<ApiResponse<RegistrationFormDataPatch>>(
+          GUEST_USER,
+          guestPayload,
+          {
+            headers: { 'X-Guest-Token': `${userToken}` },
+          },
+        );
+        // Use the response data, which should include identification_code
+        // Merge response data with existing user data to maintain all required fields
+        updatedUser = { ...updatedUser, ...(userResp.data.data || {}) };
+      } else {
+        // New cognito flow
+        await updateCognitoUser(user);
+      }
+    } catch (e: any) {
+      // Handle authentication errors specifically
+      if (
+        handleAuthError(e, {
+          userType: userType === 'case_manager' ? 'cognito' : userType,
+          redirectPath: userType === 'cognito' || userType === 'case_manager' ? '/login' : '/',
+          showToast,
+        })
+      ) {
+        // Auth error was handled, exit early
+        return;
+      }
+      // Handle other errors with existing error handler
+      handleRegistrationError(e, userType);
+      return; // Exit early on error
+    }
+    try {
+      // Prepare headers based on user type
+      const headers: any =
+        userType === 'guest'
+          ? { 'X-Guest-Token': `${userToken}` }
+          : { Authorization: `Bearer ${getCognitoToken()}` };
 
-			// Build registration payload with counts based on user type
-			const basePayload = eventSlotId
-				? {
-						event_id: selectedEvent.eventId,
-						event_date_id,
-						event_slot_id,
-					}
-				: { event_id: selectedEvent.eventId, event_date_id };
+      // Build registration payload with counts based on user type
+      const basePayload = eventSlotId
+        ? {
+            event_id: selectedEvent.eventId,
+            event_date_id,
+            event_slot_id,
+          }
+        : { event_id: selectedEvent.eventId, event_date_id };
 
-			// Add counts in appropriate format based on user type
-			// Guest users: flat fields (seniors, adults, children)
-			// Registered users and case managers: nested counts object
-			const countsPayload =
-				userType === "guest"
-					? {
-							seniors: updatedUser.seniors_in_household || 0,
-							adults: updatedUser.adults_in_household || 0,
-							children: updatedUser.children_in_household || 0,
-						}
-					: {
-							counts: {
-								seniors: updatedUser.seniors_in_household || 0,
-								adults: updatedUser.adults_in_household || 0,
-								children:
-									updatedUser.children_in_household || 0,
-							},
-						};
+      // Add counts in appropriate format based on user type
+      // Guest users: flat fields (seniors, adults, children)
+      // Registered users and case managers: nested counts object
+      const countsPayload =
+        userType === 'guest'
+          ? {
+              seniors: updatedUser.seniors_in_household || 0,
+              adults: updatedUser.adults_in_household || 0,
+              children: updatedUser.children_in_household || 0,
+            }
+          : {
+              counts: {
+                seniors: updatedUser.seniors_in_household || 0,
+                adults: updatedUser.adults_in_household || 0,
+                children: updatedUser.children_in_household || 0,
+              },
+            };
 
-			// For case managers, include registrant info so the backend creates a user on their behalf
-			const registrantPayload =
-				userType === "case_manager"
-					? {
-							registrant: {
-								first_name: updatedUser.first_name,
-								last_name: updatedUser.last_name,
-								suffix: updatedUser.suffix || undefined,
-								gender: updatedUser.gender || undefined,
-								email: updatedUser.email || undefined,
-								date_of_birth:
-									updatedUser.date_of_birth || undefined,
-								phone: updatedUser.phone
-									? updatedUser.phone.replace(/\D/g, "")
-									: undefined,
-								address_line_1: updatedUser.address_line_1,
-								address_line_2: updatedUser.address_line_2,
-								city: updatedUser.city,
-								state: updatedUser.state,
-								zip_code: updatedUser.zip_code,
-								seniors: updatedUser.seniors_in_household || 0,
-								adults: updatedUser.adults_in_household || 0,
-								children:
-									updatedUser.children_in_household || 0,
-							},
-						}
-					: {};
+      // For case managers, include registrant info so the backend creates a user on their behalf
+      const registrantPayload =
+        userType === 'case_manager'
+          ? {
+              registrant: {
+                first_name: updatedUser.first_name,
+                last_name: updatedUser.last_name,
+                suffix: updatedUser.suffix || undefined,
+                gender: updatedUser.gender || undefined,
+                email: updatedUser.email || undefined,
+                date_of_birth: updatedUser.date_of_birth || undefined,
+                phone: updatedUser.phone ? updatedUser.phone.replace(/\D/g, '') : undefined,
+                address_line_1: updatedUser.address_line_1,
+                address_line_2: updatedUser.address_line_2,
+                city: updatedUser.city,
+                state: updatedUser.state,
+                zip_code: updatedUser.zip_code,
+                seniors: updatedUser.seniors_in_household || 0,
+                adults: updatedUser.adults_in_household || 0,
+                children: updatedUser.children_in_household || 0,
+              },
+            }
+          : {};
 
-			await axios.post<ApiResponse<any>>(
-				CREATE_RESERVATION,
-				{ ...basePayload, ...countsPayload, ...registrantPayload },
-				{ headers },
-			);
-			TagManager.dataLayer({
-				dataLayer: {
-					event: "reservation",
-				},
-			});
-			if (updatedUser["permission_to_text"]) {
-				send_sms(updatedUser);
-			}
-			if (updatedUser["permission_to_email"]) {
-				sendRegistrationConfirmationEmail(
-					updatedUser,
-					selectedEvent,
-					location,
-				);
-			}
-			if (eventDateId) {
-				StorageService.setRegisteredEventDateID(eventDateId);
-			}
-			navigate(RENDER_URL.REGISTRATION_CONFIRM_URL, {
-				state: {
-					user: updatedUser,
-					eventDateId: eventDateId,
-					eventTimeStamp: {
-						start_time: location.state?.event_slot?.start_time,
-						end_time: location.state?.event_slot?.end_time,
-						event_slot_id: event_slot_id,
-					},
-					isCaseManager: userType === "case_manager",
-				},
-			});
-		} catch (e: any) {
-			console.error("Registration error:", e);
+      await axios.post<ApiResponse<any>>(
+        CREATE_RESERVATION,
+        { ...basePayload, ...countsPayload, ...registrantPayload },
+        { headers },
+      );
+      TagManager.dataLayer({
+        dataLayer: {
+          event: 'reservation',
+        },
+      });
+      if (updatedUser['permission_to_text']) {
+        send_sms(updatedUser);
+      }
+      if (updatedUser['permission_to_email']) {
+        sendRegistrationConfirmationEmail(updatedUser, selectedEvent, location);
+      }
+      if (eventDateId) {
+        StorageService.setRegisteredEventDateID(eventDateId);
+      }
+      navigate(RENDER_URL.REGISTRATION_CONFIRM_URL, {
+        state: {
+          user: updatedUser,
+          eventDateId: eventDateId,
+          eventTimeStamp: {
+            start_time: location.state?.event_slot?.start_time,
+            end_time: location.state?.event_slot?.end_time,
+            event_slot_id: event_slot_id,
+          },
+          isCaseManager: userType === 'case_manager',
+        },
+      });
+    } catch (e: any) {
+      console.error('Registration error:', e);
 
-			// Handle authentication errors specifically
-			if (
-				handleAuthError(e, {
-					userType:
-						userType === "case_manager" ? "cognito" : userType,
-					redirectPath:
-						userType === "cognito" || userType === "case_manager"
-							? "/login"
-							: "/",
-					showToast,
-				})
-			) {
-				// Auth error was handled, exit early
-				return;
-			}
+      // Handle authentication errors specifically
+      if (
+        handleAuthError(e, {
+          userType: userType === 'case_manager' ? 'cognito' : userType,
+          redirectPath: userType === 'cognito' || userType === 'case_manager' ? '/login' : '/',
+          showToast,
+        })
+      ) {
+        // Auth error was handled, exit early
+        return;
+      }
 
-			// Check for "already registered" error
-			if (
-				e.response &&
-				e.response.data &&
-				isAlreadyRegisteredError(e.response.data)
-			) {
-				// Redirect to already registered page instead of showing inline
-				navigate(RENDER_URL.REGISTRATION_ALREADY_REGISTERED_URL, {
-					state: {
-						eventName: selectedEvent?.agencyName,
-					},
-				});
-				setDisabled(false);
-				return;
-			}
+      // Check for "already registered" error
+      if (e.response && e.response.data && isAlreadyRegisteredError(e.response.data)) {
+        // Redirect to already registered page instead of showing inline
+        navigate(RENDER_URL.REGISTRATION_ALREADY_REGISTERED_URL, {
+          state: {
+            eventName: selectedEvent?.agencyName,
+          },
+        });
+        setDisabled(false);
+        return;
+      }
 
-			// Handle different types of errors
-			if (e.response && e.response.data) {
-				// API error with response data
-				notify(e.response.data, "error");
-			} else if (e.request) {
-				// Network error (no response received)
-				notify(
-					{
-						network_error: [
-							"Network error. Please check your connection and try again.",
-						],
-					},
-					"error",
-				);
-			} else {
-				// Other errors (like axios configuration errors)
-				notify(
-					{
-						general_error: [
-							"Something went wrong. Please try again.",
-						],
-					},
-					"error",
-				);
-			}
+      // Handle different types of errors
+      if (e.response && e.response.data) {
+        // API error with response data
+        notify(e.response.data, 'error');
+      } else if (e.request) {
+        // Network error (no response received)
+        notify(
+          {
+            network_error: ['Network error. Please check your connection and try again.'],
+          },
+          'error',
+        );
+      } else {
+        // Other errors (like axios configuration errors)
+        notify(
+          {
+            general_error: ['Something went wrong. Please try again.'],
+          },
+          'error',
+        );
+      }
 
-			setTimeout(() => window.scrollTo(0, 0));
-			setDisabled(disabled);
-			setErrors(e);
-			throw e; // Re-throw the error so it can be caught by the calling component
-		}
-	};
+      setTimeout(() => window.scrollTo(0, 0));
+      setDisabled(disabled);
+      setErrors(e);
+      throw e; // Re-throw the error so it can be caught by the calling component
+    }
+  };
 
-	if (pageError) {
-		// Format errors to match ErrorComponent interface
-		const formattedErrors = {
-			message: Array.isArray(errors)
-				? errors.join(", ")
-				: "An error occurred while loading the page.",
-			status: "error",
-		};
-		return <ErrorComponent error={formattedErrors} />;
-	}
+  if (pageError) {
+    // Format errors to match ErrorComponent interface
+    const formattedErrors = {
+      message: Array.isArray(errors)
+        ? errors.join(', ')
+        : 'An error occurred while loading the page.',
+      status: 'error',
+    };
+    return <ErrorComponent error={formattedErrors} />;
+  }
 
-	if (showAuthModal) {
-		return (
-			<AuthenticationModalComponent
-				show={showAuthModal}
-				setshow={setShowAuthModal}
-				onLogin={handleAuthLogin}
-			/>
-		);
-	}
+  if (showAuthModal) {
+    return (
+      <AuthenticationModalComponent
+        show={showAuthModal}
+        setshow={setShowAuthModal}
+        onLogin={handleAuthLogin}
+      />
+    );
+  }
 
-	// Show spinner while loading or if user/event data is not ready
-	if (
-		isLoading ||
-		!user ||
-		typeof user !== "object" ||
-		!selectedEvent ||
-		Object.keys(selectedEvent).length === 0
-	) {
-		return <SpinnerComponent />;
-	}
+  // Show spinner while loading or if user/event data is not ready
+  if (
+    isLoading ||
+    !user ||
+    typeof user !== 'object' ||
+    !selectedEvent ||
+    Object.keys(selectedEvent).length === 0
+  ) {
+    return <SpinnerComponent />;
+  }
 
-	return (
-		<Fragment>
-			{isLoading && <SpinnerComponent />}
-			<Fragment>
-				<NotifyToast />
-				<RegistrationComponent
-					user={user && typeof user === "object" ? user : defaultUser}
-					onRegister={(data: RegistrationFormData) =>
-						register(data, selectedEvent)
-					}
-					event={selectedEvent}
-					disabled={disabled}
-					householdMembers={householdMembers}
-				/>
-			</Fragment>
-		</Fragment>
-	);
+  return (
+    <Fragment>
+      {isLoading && <SpinnerComponent />}
+      <Fragment>
+        <NotifyToast />
+        <RegistrationComponent
+          user={user && typeof user === 'object' ? user : defaultUser}
+          onRegister={(data: RegistrationFormData) => register(data, selectedEvent)}
+          event={selectedEvent}
+          disabled={disabled}
+          householdMembers={householdMembers}
+        />
+      </Fragment>
+    </Fragment>
+  );
 };
 
 export default RegistrationContainer;

--- a/src/Modules/Registration/__test__/RegistrationContainer.test.tsx
+++ b/src/Modules/Registration/__test__/RegistrationContainer.test.tsx
@@ -24,36 +24,59 @@ jest.mock('../../../Services/ApiService', () => ({
   sendRegistrationConfirmationEmail: jest.fn(),
 }));
 
+const mockGetUsersMe = jest.fn();
+const mockUpdateHousehold = jest.fn().mockResolvedValue({});
+
+const defaultHouseholdData = {
+  members: [
+    {
+      user_id: '1',
+      first_name: 'Jane',
+      last_name: 'Smith',
+      middle_name: 'A',
+      gender_id: 2,
+      suffix_id: null,
+      date_of_birth: '1985-06-15',
+    },
+  ],
+  address_line_1: '456 Oak Ave',
+  address_line_2: 'Apt 3',
+  city: 'Springfield',
+  state: 'IL',
+  zip_code: '62701',
+  phone: '5555551234',
+  email: 'jane@household.com',
+  permission_to_text: true,
+  permission_to_email: true,
+  identification_code: 'HOUSE123',
+  counts: {
+    seniors: 1,
+    adults: 2,
+    children: 1,
+    total: 4,
+  },
+};
+
 jest.mock('../../../Services/HouseholdsApiService', () => ({
   HouseholdsApiService: jest.fn().mockImplementation(() => ({
-    getUsersMe: jest.fn().mockResolvedValue({
-      members: [
-        {
-          user_id: '1',
-          first_name: 'John',
-          last_name: 'Doe',
-        },
-      ],
-      address_line_1: '123 Main St',
-      city: 'Test City',
-      state: 'CA',
-      zip_code: '12345',
-      phone: '1234567890',
-      email: 'john@example.com',
-      counts: {
-        seniors: 0,
-        adults: 1,
-        children: 0,
-        total: 1,
-      },
-    }),
-    updateHousehold: jest.fn().mockResolvedValue({}),
+    getUsersMe: (...args: any[]) => mockGetUsersMe(...args),
+    updateHousehold: (...args: any[]) => mockUpdateHousehold(...args),
   })),
 }));
 
 jest.mock('../RegistrationComponent', () => {
-  return function MockRegistrationComponent() {
-    return <div data-testid="registration-component">Registration Component</div>;
+  return function MockRegistrationComponent({ user }: { user: any }) {
+    return (
+      <div data-testid="registration-component">
+        <span data-testid="user-first-name">{user?.first_name}</span>
+        <span data-testid="user-last-name">{user?.last_name}</span>
+        <span data-testid="user-address">{user?.address_line_1}</span>
+        <span data-testid="user-city">{user?.city}</span>
+        <span data-testid="user-phone">{user?.phone}</span>
+        <span data-testid="user-email">{user?.email}</span>
+        <span data-testid="user-dob">{user?.date_of_birth}</span>
+      </div>
+    );
   };
 });
 
@@ -89,6 +112,11 @@ jest.mock('../../../Utils/StorageService', () => {
     isLoggedInUser: jest.fn(),
     isGuestUser: jest.fn(),
     isCaseManager: jest.fn(),
+    setRegisteredEventDateID: jest.fn(),
+    setItem: jest.fn(),
+    getItem: jest.fn().mockReturnValue(null),
+    setGuestSessionMarker: jest.fn(),
+    clearAuthData: jest.fn(),
   };
   return {
     StorageService: mockStorageService,
@@ -138,6 +166,10 @@ describe('RegistrationContainer', () => {
     mockStorageService.isGuestUser.mockReturnValue(false);
     mockStorageService.isCaseManager.mockReturnValue(false);
 
+    // Default household API response
+    mockGetUsersMe.mockResolvedValue(defaultHouseholdData);
+    mockUpdateHousehold.mockResolvedValue({});
+
     // Mock environment variables
     process.env.REACT_APP_CLIENT_URL = 'http://localhost:3000';
 
@@ -156,12 +188,16 @@ describe('RegistrationContainer', () => {
     });
   });
 
-  const renderWithProviders = (component: React.ReactElement, route = '/register/form/1') => {
+  const renderWithProviders = (
+    component: React.ReactElement,
+    routeEntry: string | { pathname: string; state?: Record<string, unknown> } = '/register/form/1',
+  ) => {
     return render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[route]}>
+        <MemoryRouter initialEntries={[routeEntry]}>
           <Routes>
             <Route path="/register/form/:eventDateId" element={component} />
+            <Route path="/register/form/:eventDateId/:eventSlotId" element={component} />
           </Routes>
         </MemoryRouter>
       </Provider>,
@@ -213,6 +249,116 @@ describe('RegistrationContainer', () => {
       },
       { timeout: 1000 },
     );
+  });
+
+  describe('RSVP path household prefill', () => {
+    const cognitoUser = { name: 'Cognito User', email: 'cognito@test.com' };
+
+    beforeEach(() => {
+      // Simulate an authenticated Cognito user with no router state (RSVP path)
+      mockStorageService.isLoggedInUser.mockReturnValue(true);
+      mockStorageService.getCognitoUser.mockReturnValue(cognitoUser);
+      mockStorageService.isCaseManager.mockReturnValue(false);
+    });
+
+    it('calls getUsersMe to prefill household data when no householdData in router state', async () => {
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(() => {
+        expect(mockGetUsersMe).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('prefills address fields from household API response on RSVP path', async () => {
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('user-address')).toHaveTextContent('456 Oak Ave');
+        },
+        { timeout: 3000 },
+      );
+
+      expect(screen.getByTestId('user-city')).toHaveTextContent('Springfield');
+      expect(screen.getByTestId('user-phone')).toHaveTextContent('5555551234');
+      expect(screen.getByTestId('user-email')).toHaveTextContent('jane@household.com');
+    });
+
+    it('prefills name fields from primary household member on RSVP path', async () => {
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('user-first-name')).toHaveTextContent('Jane');
+        },
+        { timeout: 3000 },
+      );
+
+      expect(screen.getByTestId('user-last-name')).toHaveTextContent('Smith');
+    });
+
+    it('does NOT call getUsersMe when householdData is already in router state (Register path)', async () => {
+      renderWithProviders(<RegistrationContainer />, {
+        pathname: '/register/form/1',
+        state: {
+          householdData: defaultHouseholdData,
+          event_slot: { event_slot_id: 10, start_time: '09:00', end_time: '10:00' },
+          event_date: '2024-01-01',
+        },
+      });
+
+      // Allow effects to settle
+      await waitFor(() => {
+        expect(screen.getByTestId('registration-component')).toBeInTheDocument();
+      });
+
+      // getUsersMe should not have been called for the RSVP prefill path
+      expect(mockGetUsersMe).not.toHaveBeenCalled();
+    });
+
+    it('renders form with Cognito fallback when getUsersMe API call fails', async () => {
+      mockGetUsersMe.mockRejectedValue(new Error('Network error'));
+
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      // Form should still render using Cognito defaults
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('registration-component')).toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+
+      // Name should fall back to Cognito user data
+      expect(screen.getByTestId('user-first-name')).toHaveTextContent('Cognito');
+    });
+
+    it('does not call getUsersMe for case managers', async () => {
+      mockStorageService.isCaseManager.mockReturnValue(true);
+
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('registration-component')).toBeInTheDocument();
+      });
+
+      expect(mockGetUsersMe).not.toHaveBeenCalled();
+    });
+
+    it('does not call getUsersMe for unauthenticated users', async () => {
+      mockStorageService.isLoggedInUser.mockReturnValue(false);
+      mockStorageService.getCognitoUser.mockReturnValue(null);
+      mockStorageService.isGuestUser.mockReturnValue(false);
+      mockStorageService.getUserToken.mockReturnValue(null);
+
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('auth-modal')).toBeInTheDocument();
+      });
+
+      expect(mockGetUsersMe).not.toHaveBeenCalled();
+    });
   });
 
   test('always fetches fresh event data based on URL eventDateId', async () => {

--- a/src/Modules/Registration/__test__/RegistrationContainer.test.tsx
+++ b/src/Modules/Registration/__test__/RegistrationContainer.test.tsx
@@ -316,12 +316,43 @@ describe('RegistrationContainer', () => {
       expect(mockGetUsersMe).not.toHaveBeenCalled();
     });
 
+    it('holds the spinner until getUsersMe resolves (no early form render)', async () => {
+      // Delay the API response so we can assert the spinner is present before it resolves
+      let resolveHousehold!: (v: typeof defaultHouseholdData) => void;
+      mockGetUsersMe.mockReturnValue(
+        new Promise<typeof defaultHouseholdData>((res) => {
+          resolveHousehold = res;
+        }),
+      );
+
+      renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      // Wait for the event to load (spinner from isLoading clears), but household fetch still in-flight
+      await waitFor(() => {
+        expect(mockGetUsersMe).toHaveBeenCalledTimes(1);
+      });
+
+      // The form must not be visible while prefill is still loading
+      expect(screen.queryByTestId('registration-component')).not.toBeInTheDocument();
+
+      // Now resolve the household fetch
+      await act(async () => {
+        resolveHousehold(defaultHouseholdData);
+      });
+
+      // Form should now appear with household data
+      await waitFor(() => {
+        expect(screen.getByTestId('registration-component')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('user-address')).toHaveTextContent('456 Oak Ave');
+    });
+
     it('renders form with Cognito fallback when getUsersMe API call fails', async () => {
       mockGetUsersMe.mockRejectedValue(new Error('Network error'));
 
       renderWithProviders(<RegistrationContainer />, '/register/form/1');
 
-      // Form should still render using Cognito defaults
+      // Form should still render using Cognito defaults after the failed fetch
       await waitFor(
         () => {
           expect(screen.getByTestId('registration-component')).toBeInTheDocument();
@@ -333,9 +364,31 @@ describe('RegistrationContainer', () => {
       expect(screen.getByTestId('user-first-name')).toHaveTextContent('Cognito');
     });
 
+    it('resets the fetch guard after a failure so the next navigation can retry', async () => {
+      // First navigation — API fails
+      mockGetUsersMe.mockRejectedValueOnce(new Error('Network error'));
+
+      const { unmount } = renderWithProviders(<RegistrationContainer />, '/register/form/1');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('registration-component')).toBeInTheDocument();
+      });
+
+      // Guard must have been reset so re-mount (simulating a new navigation) retries
+      unmount();
+      mockGetUsersMe.mockResolvedValue(defaultHouseholdData);
+
+      renderWithProviders(<RegistrationContainer />, '/register/form/2');
+
+      await waitFor(() => {
+        expect(mockGetUsersMe).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('does not call getUsersMe for case managers', async () => {
       mockStorageService.isCaseManager.mockReturnValue(true);
-
+      // For case managers isHouseholdPrefillLoading initialises to false, so
+      // the form renders without needing a household fetch.
       renderWithProviders(<RegistrationContainer />, '/register/form/1');
 
       await waitFor(() => {

--- a/src/Modules/Registration/__test__/registrationConfirmComponent.test.tsx
+++ b/src/Modules/Registration/__test__/registrationConfirmComponent.test.tsx
@@ -1,426 +1,391 @@
-import * as React from "react";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { preformattedEventData, mockFamily } from "../../../Testing";
-import RegistrationConfirmComponent from "../RegistrationConfirmComponent";
-import { Event, RegistrationFormData } from "../types/registration.types";
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { preformattedEventData, mockFamily } from '../../../Testing';
+import RegistrationConfirmComponent from '../RegistrationConfirmComponent';
+import { Event, RegistrationFormData } from '../types/registration.types';
 
-jest.mock("axios");
-const mockAxios = require("axios");
+jest.mock('axios');
+const mockAxios = require('axios');
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-	const actual = jest.requireActual("react-router-dom");
-	const React = jest.requireActual("react");
-	const withFutureFlags = (RouterComponent: React.ComponentType<any>) => {
-		const WrappedRouter = ({ future, ...props }: any) =>
-			React.createElement(RouterComponent, {
-				...props,
-				future: {
-					v7_startTransition: true,
-					v7_relativeSplatPath: true,
-					...(future || {}),
-				},
-			});
-		return WrappedRouter;
-	};
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  const React = jest.requireActual('react');
+  const withFutureFlags = (RouterComponent: React.ComponentType<any>) => {
+    const WrappedRouter = ({ future, ...props }: any) =>
+      React.createElement(RouterComponent, {
+        ...props,
+        future: {
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+          ...(future || {}),
+        },
+      });
+    return WrappedRouter;
+  };
 
-	return {
-		...actual,
-		useNavigate: () => mockNavigate,
-		MemoryRouter: withFutureFlags(actual.MemoryRouter),
-		BrowserRouter: withFutureFlags(actual.BrowserRouter),
-	};
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    MemoryRouter: withFutureFlags(actual.MemoryRouter),
+    BrowserRouter: withFutureFlags(actual.BrowserRouter),
+  };
 });
 
-jest.mock("../../../Utils/StorageService", () => ({
-	StorageService: {
-		getRegisteredEventDateID: jest.fn().mockReturnValue("123"),
-		getItem: jest.fn().mockReturnValue("true"),
-		clearUserToken: jest.fn(),
-		removeItem: jest.fn(),
-		isGuestUser: jest.fn().mockReturnValue(false),
-		isLoggedInUser: jest.fn().mockReturnValue(true),
-		isCaseManager: jest.fn().mockReturnValue(false),
-	},
+jest.mock('../../../Utils/StorageService', () => ({
+  StorageService: {
+    getRegisteredEventDateID: jest.fn().mockReturnValue('123'),
+    getItem: jest.fn().mockReturnValue('true'),
+    clearUserToken: jest.fn(),
+    removeItem: jest.fn(),
+    isGuestUser: jest.fn().mockReturnValue(false),
+    isLoggedInUser: jest.fn().mockReturnValue(true),
+    isCaseManager: jest.fn().mockReturnValue(false),
+  },
 }));
 
-jest.mock("../../Localization/LocalizationComponent", () => ({
-	__esModule: true,
-	default: {
-		title_youre_registered: "You're Registered!",
-		header_your_confirmation_number: "Your Confirmation Number:",
-		header_your_qr_code: "Your QR Code",
-		header_your_information: "Your Information",
-		header_head_of_household: "Head of Household",
-		header_additional_location_information: "Additional Location Information",
-		button_back_to_home: "Back to Home",
-		button_print: "Print",
-		button_save: "Save",
-		button_cancel: "Cancel",
-		button_continue: "Continue",
-		aria_print_confirmation: "Print confirmation",
-		aria_save_confirmation: "Save confirmation",
-		cm_register_another: "Register Another Person",
-		cm_registration_complete: "Registration Complete!",
-		cm_save_before_leaving_title: "Save Confirmation?",
-		cm_save_before_leaving_description:
-			"Have you saved or printed the confirmation information?",
-		family_member_count_plural: "family members",
-		dialog_create_account_title: "Create an Account",
-		dialog_create_account_description: "Save your information for next time",
-		guest_signin_button: "Sign In / Create Account",
-	},
+jest.mock('../../Localization/LocalizationComponent', () => ({
+  __esModule: true,
+  default: {
+    title_youre_registered: "You're Registered!",
+    header_your_confirmation_number: 'Your Confirmation Number:',
+    header_your_qr_code: 'Your QR Code',
+    header_your_information: 'Your Information',
+    header_head_of_household: 'Head of Household',
+    header_additional_location_information: 'Additional Location Information',
+    button_back_to_home: 'Back to Home',
+    button_print: 'Print',
+    button_save: 'Save',
+    button_cancel: 'Cancel',
+    button_continue: 'Continue',
+    aria_print_confirmation: 'Print confirmation',
+    aria_save_confirmation: 'Save confirmation',
+    cm_register_another: 'Register Another Person',
+    cm_registration_complete: 'Registration Complete!',
+    cm_save_before_leaving_title: 'Save Confirmation?',
+    cm_save_before_leaving_description: 'Have you saved or printed the confirmation information?',
+    family_member_count_plural: 'family members',
+    dialog_create_account_title: 'Create an Account',
+    dialog_create_account_description: 'Save your information for next time',
+    guest_signin_button: 'Sign In / Create Account',
+  },
 }));
 
-jest.mock("../components/PrintableConfirmationCard", () => {
-	const MockPrintable = () => (
-		<div data-testid="printable-card">Printable</div>
-	);
-	return {
-		__esModule: true,
-		default: MockPrintable,
-		generateConfirmationCardPNG: jest.fn().mockResolvedValue(undefined),
-	};
+jest.mock('../components/PrintableConfirmationCard', () => {
+  const MockPrintable = () => <div data-testid="printable-card">Printable</div>;
+  return {
+    __esModule: true,
+    default: MockPrintable,
+    generateConfirmationCardPNG: jest.fn().mockResolvedValue(undefined),
+  };
 });
 
-jest.mock("../../../Utils/sanitizeHtml", () => ({
-	sanitizeHtml: (html: string) => html,
+jest.mock('../../../Utils/sanitizeHtml', () => ({
+  sanitizeHtml: (html: string) => html,
 }));
 
 // Type definitions for test data
 interface TestState {
-	event: { event: Event };
-	user: { user: RegistrationFormData };
+  event: { event: Event };
+  user: { user: RegistrationFormData };
 }
 
 interface LocationState {
-	state: {
-		user: RegistrationFormData;
-		eventTimeStamp: Record<string, any>;
-	};
+  state: {
+    user: RegistrationFormData;
+    eventTimeStamp: Record<string, any>;
+  };
 }
 
 const eventData = {
-	...preformattedEventData,
-	acceptWalkin: true,
-	eventName: "Test Food Drive",
+  ...preformattedEventData,
+  acceptWalkin: true,
+  eventName: 'Test Food Drive',
 } as Event;
 
 const eventDetailsApiResponse = {
-	address: "123 Test St",
-	city: "Test City",
-	state: "TS",
-	zip: "12345",
-	forms: [],
-	agency_name: "Test Agency",
-	name: "Test Food Drive",
-	exception_note: "",
-	estimated_distance: 0,
-	service_category: { service_category_name: "Food" },
-	event_details: "",
-	event_dates: [
-		{
-			id: 123,
-			event_id: 1,
-			accept_reservations: true,
-			accept_interest: false,
-			accept_walkin: true,
-			start_time: "09:00 AM",
-			end_time: "10:00 AM",
-			date: "2024-01-01",
-		},
-	],
+  address: '123 Test St',
+  city: 'Test City',
+  state: 'TS',
+  zip: '12345',
+  forms: [],
+  agency_name: 'Test Agency',
+  name: 'Test Food Drive',
+  exception_note: '',
+  estimated_distance: 0,
+  service_category: { service_category_name: 'Food' },
+  event_details: '',
+  event_dates: [
+    {
+      id: 123,
+      event_id: 1,
+      accept_reservations: true,
+      accept_interest: false,
+      accept_walkin: true,
+      start_time: '09:00 AM',
+      end_time: '10:00 AM',
+      date: '2024-01-01',
+    },
+  ],
 };
 
 const initialState: TestState = {
-	event: { event: eventData },
-	user: { user: mockFamily },
+  event: { event: eventData },
+  user: { user: mockFamily },
 };
 
 const mockStore = (configureStore as any)([]);
 
 // Mock canvas context for QR code rendering
 window.HTMLCanvasElement.prototype.getContext = function (contextId: string) {
-	if (contextId === "2d") {
-		return {} as CanvasRenderingContext2D;
-	}
-	return null;
+  if (contextId === '2d') {
+    return {} as CanvasRenderingContext2D;
+  }
+  return null;
 } as any;
 
 const renderWithState = (
-	locationState: Record<string, any>,
-	storeOverrides?: Partial<TestState>,
+  locationState: Record<string, any>,
+  storeOverrides?: Partial<TestState>,
 ) => {
-	const store = mockStore({ ...initialState, ...storeOverrides });
-	return render(
-		<Provider store={store}>
-			<MemoryRouter
-				initialEntries={[{ pathname: "/confirmation", state: locationState }]}
-			>
-				<Routes>
-					<Route
-						path="/confirmation"
-						element={<RegistrationConfirmComponent />}
-					/>
-				</Routes>
-			</MemoryRouter>
-		</Provider>,
-	);
+  const store = mockStore({ ...initialState, ...storeOverrides });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: '/confirmation', state: locationState }]}>
+        <Routes>
+          <Route path="/confirmation" element={<RegistrationConfirmComponent />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
 };
 
-describe("RegistrationConfirmComponent", () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		mockNavigate.mockClear();
-		mockAxios.get.mockResolvedValue({
-			data: { event: eventDetailsApiResponse },
-		});
-	});
+describe('RegistrationConfirmComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNavigate.mockClear();
+    mockAxios.get.mockResolvedValue({
+      data: { event: eventDetailsApiResponse },
+    });
+  });
 
-	it("should render without errors", () => {
-		const store = mockStore(initialState);
-		expect(() => {
-			render(
-				<Provider store={store}>
-					<MemoryRouter>
-						<RegistrationConfirmComponent
-							location={
-								{
-									state: {
-										user: mockFamily,
-										eventTimeStamp: {},
-									},
-								} as LocationState
-							}
-						/>
-					</MemoryRouter>
-				</Provider>,
-			);
-		}).not.toThrow();
-	});
+  it('should render without errors', () => {
+    const store = mockStore(initialState);
+    expect(() => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <RegistrationConfirmComponent
+              location={
+                {
+                  state: {
+                    user: mockFamily,
+                    eventTimeStamp: {},
+                  },
+                } as LocationState
+              }
+            />
+          </MemoryRouter>
+        </Provider>,
+      );
+    }).not.toThrow();
+  });
 
-	it("should load without errors with empty event", async () => {
-		const emptyStore = mockStore({
-			event: { event: {} as Event },
-			user: { user: mockFamily },
-		});
-		const user_mock_data: LocationState = {
-			state: { user: mockFamily, eventTimeStamp: {} },
-		};
+  it('should load without errors with empty event', async () => {
+    const emptyStore = mockStore({
+      event: { event: {} as Event },
+      user: { user: mockFamily },
+    });
+    const user_mock_data: LocationState = {
+      state: { user: mockFamily, eventTimeStamp: {} },
+    };
 
-		render(
-			<Provider store={emptyStore}>
-				<MemoryRouter>
-					<RegistrationConfirmComponent location={user_mock_data} />
-				</MemoryRouter>
-			</Provider>,
-		);
+    render(
+      <Provider store={emptyStore}>
+        <MemoryRouter>
+          <RegistrationConfirmComponent location={user_mock_data} />
+        </MemoryRouter>
+      </Provider>,
+    );
 
-		await waitFor(() => {
-			expect(mockAxios.get).toHaveBeenCalled();
-		});
-	});
+    await waitFor(() => {
+      expect(mockAxios.get).toHaveBeenCalled();
+    });
+  });
 
-	it("should show the event data and user data", () => {
-		const user_mock_data: LocationState = {
-			state: { user: mockFamily, eventTimeStamp: {} },
-		};
-		const { identification_code } = mockFamily;
-		const testStore = mockStore({
-			event: {
-				event: {
-					...preformattedEventData,
-					acceptWalkin: true,
-				} as Event,
-			},
-			user: { user: mockFamily },
-		});
+  it('should show the event data and user data', () => {
+    const user_mock_data: LocationState = {
+      state: { user: mockFamily, eventTimeStamp: {} },
+    };
+    const { identification_code } = mockFamily;
+    const testStore = mockStore({
+      event: {
+        event: {
+          ...preformattedEventData,
+          acceptWalkin: true,
+        } as Event,
+      },
+      user: { user: mockFamily },
+    });
 
-		const { getAllByText } = render(
-			<Provider store={testStore}>
-				<MemoryRouter>
-					<RegistrationConfirmComponent location={user_mock_data} />
-				</MemoryRouter>
-			</Provider>,
-		);
+    const { getAllByText } = render(
+      <Provider store={testStore}>
+        <MemoryRouter>
+          <RegistrationConfirmComponent location={user_mock_data} />
+        </MemoryRouter>
+      </Provider>,
+    );
 
-		// Verify the identification code is displayed (appears in multiple places)
-		const identificationCodes = getAllByText(identification_code);
-		expect(identificationCodes.length).toBeGreaterThan(0);
-	});
+    // Verify the identification code is displayed (appears in multiple places)
+    const identificationCodes = getAllByText(identification_code);
+    expect(identificationCodes.length).toBeGreaterThan(0);
+  });
 
-	describe("Case Manager confirmation view", () => {
-		const cmLocationState = {
-			user: mockFamily,
-			eventTimeStamp: { start_time: "9:00 AM", end_time: "10:00 AM" },
-			isCaseManager: true,
-			eventDateId: "456",
-		};
+  describe('Case Manager confirmation view', () => {
+    const cmLocationState = {
+      user: mockFamily,
+      eventTimeStamp: { start_time: '9:00 AM', end_time: '10:00 AM' },
+      isCaseManager: true,
+      eventDateId: '456',
+    };
 
-		it("shows Registration Complete heading for case managers", () => {
-			renderWithState(cmLocationState);
-			expect(
-				screen.getByText("Registration Complete!"),
-			).toBeInTheDocument();
-		});
+    it('shows Registration Complete heading for case managers', () => {
+      renderWithState(cmLocationState);
+      expect(screen.getByText('Registration Complete!')).toBeInTheDocument();
+    });
 
-		it("shows Register Another Person button", () => {
-			renderWithState(cmLocationState);
-			expect(
-				screen.getByText("Register Another Person"),
-			).toBeInTheDocument();
-		});
+    it('shows Register Another Person button', () => {
+      renderWithState(cmLocationState);
+      expect(screen.getByText('Register Another Person')).toBeInTheDocument();
+    });
 
-		it("shows Back to Home button", () => {
-			renderWithState(cmLocationState);
-			const homeButtons = screen.getAllByText("Back to Home");
-			expect(homeButtons.length).toBeGreaterThan(0);
-		});
+    it('shows Back to Home button', () => {
+      renderWithState(cmLocationState);
+      const homeButtons = screen.getAllByText('Back to Home');
+      expect(homeButtons.length).toBeGreaterThan(0);
+    });
 
-		it("navigates to home when Back to Home is clicked", () => {
-			renderWithState(cmLocationState);
-			const homeButtons = screen.getAllByText("Back to Home");
-			fireEvent.click(homeButtons[0]);
-			expect(mockNavigate).toHaveBeenCalledWith("/");
-		});
+    it('navigates to home when Back to Home is clicked', () => {
+      renderWithState(cmLocationState);
+      const homeButtons = screen.getAllByText('Back to Home');
+      fireEvent.click(homeButtons[0]);
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
 
-		it("shows save confirmation dialog when Register Another is clicked", async () => {
-			renderWithState(cmLocationState);
-			fireEvent.click(screen.getByText("Register Another Person"));
+    it('shows save confirmation dialog when Register Another is clicked', async () => {
+      renderWithState(cmLocationState);
+      fireEvent.click(screen.getByText('Register Another Person'));
 
-			await waitFor(() => {
-				expect(
-					screen.getByText("Save Confirmation?"),
-				).toBeInTheDocument();
-				expect(
-					screen.getByText(
-						"Have you saved or printed the confirmation information?",
-					),
-				).toBeInTheDocument();
-			});
-		});
+      await waitFor(() => {
+        expect(screen.getByText('Save Confirmation?')).toBeInTheDocument();
+        expect(
+          screen.getByText('Have you saved or printed the confirmation information?'),
+        ).toBeInTheDocument();
+      });
+    });
 
-		it("closes dialog when Cancel is clicked", async () => {
-			renderWithState(cmLocationState);
-			fireEvent.click(screen.getByText("Register Another Person"));
+    it('closes dialog when Cancel is clicked', async () => {
+      renderWithState(cmLocationState);
+      fireEvent.click(screen.getByText('Register Another Person'));
 
-			await waitFor(() => {
-				expect(
-					screen.getByText("Save Confirmation?"),
-				).toBeInTheDocument();
-			});
+      await waitFor(() => {
+        expect(screen.getByText('Save Confirmation?')).toBeInTheDocument();
+      });
 
-			fireEvent.click(screen.getByText("Cancel"));
+      fireEvent.click(screen.getByText('Cancel'));
 
-			await waitFor(() => {
-				expect(
-					screen.queryByText("Save Confirmation?"),
-				).not.toBeInTheDocument();
-			});
-		});
+      await waitFor(() => {
+        expect(screen.queryByText('Save Confirmation?')).not.toBeInTheDocument();
+      });
+    });
 
-		it("navigates to event registration when Continue is clicked", async () => {
-			renderWithState(cmLocationState);
-			fireEvent.click(screen.getByText("Register Another Person"));
-			const continueButton = await screen.findByText("Continue");
-			fireEvent.click(continueButton);
+    it('navigates to event registration when Continue is clicked', async () => {
+      renderWithState(cmLocationState);
+      fireEvent.click(screen.getByText('Register Another Person'));
+      const continueButton = await screen.findByText('Continue');
+      fireEvent.click(continueButton);
 
-			expect(mockNavigate).toHaveBeenCalledWith(
-				expect.stringContaining("/456"),
-			);
-		});
+      expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/456'));
+    });
 
-		it("displays registrant information", () => {
-			renderWithState(cmLocationState);
-			expect(
-				screen.getByText(mockFamily.first_name, { exact: false }),
-			).toBeInTheDocument();
-		});
+    it('displays registrant information', () => {
+      renderWithState(cmLocationState);
+      expect(
+        screen.getByRole('heading', {
+          level: 3,
+          name: new RegExp(mockFamily.first_name, 'i'),
+        }),
+      ).toBeInTheDocument();
+    });
 
-		it("shows print and save buttons", () => {
-			renderWithState(cmLocationState);
-			expect(
-				screen.getByRole("button", { name: "Print confirmation" }),
-			).toBeInTheDocument();
-			expect(
-				screen.getByRole("button", { name: "Save confirmation" }),
-			).toBeInTheDocument();
-		});
+    it('shows print and save buttons', () => {
+      renderWithState(cmLocationState);
+      expect(screen.getByRole('button', { name: 'Print confirmation' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save confirmation' })).toBeInTheDocument();
+    });
 
-		it("does not show the regular user view", () => {
-			renderWithState(cmLocationState);
-			expect(
-				screen.queryByText("You're Registered!"),
-			).not.toBeInTheDocument();
-		});
+    it('does not show the regular user view', () => {
+      renderWithState(cmLocationState);
+      expect(screen.queryByText("You're Registered!")).not.toBeInTheDocument();
+    });
 
-		it("does not show Register Another when eventDateId is missing", () => {
-			const stateWithoutDateId = {
-				...cmLocationState,
-				eventDateId: undefined,
-			};
-			renderWithState(stateWithoutDateId);
-			expect(
-				screen.queryByText("Register Another Person"),
-			).not.toBeInTheDocument();
-		});
-	});
+    it('does not show Register Another when eventDateId is missing', () => {
+      const stateWithoutDateId = {
+        ...cmLocationState,
+        eventDateId: undefined,
+      };
+      renderWithState(stateWithoutDateId);
+      expect(screen.queryByText('Register Another Person')).not.toBeInTheDocument();
+    });
+  });
 
-	describe("Regular user confirmation view", () => {
-		const regularLocationState = {
-			user: mockFamily,
-			eventTimeStamp: {},
-			isCaseManager: false,
-		};
+  describe('Regular user confirmation view', () => {
+    const regularLocationState = {
+      user: mockFamily,
+      eventTimeStamp: {},
+      isCaseManager: false,
+    };
 
-		it("shows You're Registered heading for regular users", () => {
-			renderWithState(regularLocationState);
-			expect(
-				screen.getByText("You're Registered!"),
-			).toBeInTheDocument();
-		});
+    it("shows You're Registered heading for regular users", () => {
+      renderWithState(regularLocationState);
+      expect(screen.getByText("You're Registered!")).toBeInTheDocument();
+    });
 
-		it("does not show Register Another Person button", () => {
-			renderWithState(regularLocationState);
-			expect(
-				screen.queryByText("Register Another Person"),
-			).not.toBeInTheDocument();
-		});
+    it('does not show Register Another Person button', () => {
+      renderWithState(regularLocationState);
+      expect(screen.queryByText('Register Another Person')).not.toBeInTheDocument();
+    });
 
-		it("does not show the CM view", () => {
-			renderWithState(regularLocationState);
-			expect(
-				screen.queryByText("Registration Complete!"),
-			).not.toBeInTheDocument();
-		});
-	});
+    it('does not show the CM view', () => {
+      renderWithState(regularLocationState);
+      expect(screen.queryByText('Registration Complete!')).not.toBeInTheDocument();
+    });
+  });
 
-	describe("Guest sign-in modal", () => {
-		it("does not show guest modal for case managers", async () => {
-			jest.useFakeTimers();
-			const { StorageService } = require("../../../Utils/StorageService");
-			StorageService.isGuestUser.mockReturnValue(true);
-			StorageService.isLoggedInUser.mockReturnValue(false);
+  describe('Guest sign-in modal', () => {
+    it('does not show guest modal for case managers', async () => {
+      jest.useFakeTimers();
+      const { StorageService } = require('../../../Utils/StorageService');
+      StorageService.isGuestUser.mockReturnValue(true);
+      StorageService.isLoggedInUser.mockReturnValue(false);
 
-			renderWithState({
-				user: mockFamily,
-				eventTimeStamp: {},
-				isCaseManager: true,
-				eventDateId: "456",
-			});
+      renderWithState({
+        user: mockFamily,
+        eventTimeStamp: {},
+        isCaseManager: true,
+        eventDateId: '456',
+      });
 
-			await act(async () => {
-				jest.advanceTimersByTime(4000);
-			});
+      await act(async () => {
+        jest.advanceTimersByTime(4000);
+      });
 
-			expect(
-				screen.queryByText("Create an Account"),
-			).not.toBeInTheDocument();
+      expect(screen.queryByText('Create an Account')).not.toBeInTheDocument();
 
-			jest.useRealTimers();
-		});
-	});
+      jest.useRealTimers();
+    });
+  });
 });

--- a/src/Utils/DateFormat.js
+++ b/src/Utils/DateFormat.js
@@ -1,69 +1,78 @@
-import moment from "moment";
+import moment from 'moment';
 
 const toMoment = (value) => {
-	if (value instanceof Date) {
-		return moment(value);
-	}
+  if (value instanceof Date) {
+    return moment(value);
+  }
 
-	if (typeof value === "string") {
-		const normalizedDate = new Date(value);
-		if (!Number.isNaN(normalizedDate.getTime())) {
-			return moment(normalizedDate);
-		}
-	}
+  if (typeof value === 'string') {
+    // Date-only strings ("YYYY-MM-DD") are parsed as UTC midnight by the JS spec,
+    // which shifts the displayed date back by one day in negative-offset timezones.
+    // Appending T12:00:00 treats them as local noon, keeping the correct calendar
+    // date for any timezone within ±12 hours of UTC.
+    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T12:00:00` : value;
+    const normalizedDate = new Date(normalized);
+    if (!Number.isNaN(normalizedDate.getTime())) {
+      return moment(normalizedDate);
+    }
+  }
 
-	return moment(value);
+  return moment(value);
 };
 
-export const formatDateDayAndDate = x => toMoment(x).format("dddd, M/D/YYYY");
+export const formatDateDayAndDate = (x) => toMoment(x).format('dddd, M/D/YYYY');
 
-export const formatMMDDYYYY = x => toMoment(x).format("L");
+export const formatMMDDYYYY = (x) => toMoment(x).format('L');
 
-export const formatDateForServer = value => {
-	if (!value || typeof value !== "string") {
-		console.warn("formatDateForServer: Invalid input:", value);
-		return "";
-	}
+export const formatDateForServer = (value) => {
+  if (!value || typeof value !== 'string') {
+    console.warn('formatDateForServer: Invalid input:', value);
+    return '';
+  }
 
-	const reWhiteSpace = new RegExp("\\s+");
-	const formatted = reWhiteSpace.test(value)
-		? value.split(" / ")
-		: value.split("/");
+  const reWhiteSpace = new RegExp('\\s+');
+  const formatted = reWhiteSpace.test(value) ? value.split(' / ') : value.split('/');
 
-	if (formatted.length !== 3) {
-		console.warn("formatDateForServer: Invalid date format:", value);
-		return "";
-	}
+  if (formatted.length !== 3) {
+    console.warn('formatDateForServer: Invalid date format:', value);
+    return '';
+  }
 
-	const year = parseInt(formatted[2]);
-	const month = parseInt(formatted[0]) - 1; // Month is 0-indexed
-	const day = parseInt(formatted[1]);
+  const year = parseInt(formatted[2]);
+  const month = parseInt(formatted[0]) - 1; // Month is 0-indexed
+  const day = parseInt(formatted[1]);
 
-	// Validate the date components
-	if (isNaN(year) || isNaN(month) || isNaN(day)) {
-		console.warn("formatDateForServer: Invalid date components:", {
-			year,
-			month,
-			day,
-		});
-		return "";
-	}
+  // Validate the date components
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    console.warn('formatDateForServer: Invalid date components:', {
+      year,
+      month,
+      day,
+    });
+    return '';
+  }
 
-	if (month < 0 || month > 11) {
-		console.warn("formatDateForServer: Invalid month:", month);
-		return "";
-	}
+  if (month < 0 || month > 11) {
+    console.warn('formatDateForServer: Invalid month:', month);
+    return '';
+  }
 
-	if (day < 1 || day > 31) {
-		console.warn("formatDateForServer: Invalid day:", day);
-		return "";
-	}
+  if (day < 1 || day > 31) {
+    console.warn('formatDateForServer: Invalid day:', day);
+    return '';
+  }
 
-	try {
-		const date = new Date(year, month, day);
-		return date.toISOString().split("T")[0];
-	} catch (error) {
-		console.error("formatDateForServer: Error creating date:", error);
-		return "";
-	}
+  try {
+    // Build the YYYY-MM-DD string directly to avoid any timezone conversion.
+    // new Date(y, m, d).toISOString() can shift the date by one day for
+    // users in positive UTC-offset timezones (UTC+N), where local midnight
+    // converts to the previous calendar day in UTC.
+    const mm = String(month + 1).padStart(2, '0');
+    const dd = String(day).padStart(2, '0');
+    const yyyy = String(year);
+    return `${yyyy}-${mm}-${dd}`;
+  } catch (error) {
+    console.error('formatDateForServer: Error creating date:', error);
+    return '';
+  }
 };

--- a/src/Utils/DateFormat.js
+++ b/src/Utils/DateFormat.js
@@ -67,6 +67,17 @@ export const formatDateForServer = (value) => {
     // new Date(y, m, d).toISOString() can shift the date by one day for
     // users in positive UTC-offset timezones (UTC+N), where local midnight
     // converts to the previous calendar day in UTC.
+
+    // Verify the calendar date actually exists by constructing a local Date and
+    // confirming the parts round-trip.  JS normalises overflowing dates
+    // (e.g. Feb 31 → Mar 3) instead of throwing, so this is the reliable way
+    // to catch impossible inputs like 2000-02-31 before they reach the API.
+    const check = new Date(year, month, day);
+    if (check.getFullYear() !== year || check.getMonth() !== month || check.getDate() !== day) {
+      console.warn('formatDateForServer: Date does not exist in calendar:', value);
+      return '';
+    }
+
     const mm = String(month + 1).padStart(2, '0');
     const dd = String(day).padStart(2, '0');
     const yyyy = String(year);

--- a/src/Utils/__test__/DateFormat.test.js
+++ b/src/Utils/__test__/DateFormat.test.js
@@ -80,6 +80,26 @@ describe('DateFormat', () => {
       it('returns empty string for an invalid day (32)', () => {
         expect(formatDateForServer('08/32/1987')).toBe('');
       });
+
+      it('returns empty string for impossible calendar dates (Feb 31)', () => {
+        expect(formatDateForServer('02/31/2000')).toBe('');
+      });
+
+      it('returns empty string for impossible calendar dates (Feb 30)', () => {
+        expect(formatDateForServer('02/30/2000')).toBe('');
+      });
+
+      it('returns empty string for impossible calendar dates (Apr 31)', () => {
+        expect(formatDateForServer('04/31/2024')).toBe('');
+      });
+
+      it('accepts the last day of a month (Feb 29 on a leap year)', () => {
+        expect(formatDateForServer('02/29/2000')).toBe('2000-02-29');
+      });
+
+      it('rejects Feb 29 on a non-leap year', () => {
+        expect(formatDateForServer('02/29/2001')).toBe('');
+      });
     });
   });
 });

--- a/src/Utils/__test__/DateFormat.test.js
+++ b/src/Utils/__test__/DateFormat.test.js
@@ -1,6 +1,21 @@
-import { formatDateForServer } from '../DateFormat';
+import { formatDateDayAndDate, formatDateForServer } from '../DateFormat';
 
 describe('DateFormat', () => {
+  describe('formatDateDayAndDate', () => {
+    it('displays the correct calendar date for a YYYY-MM-DD API string regardless of local timezone', () => {
+      // Regression test: new Date("2026-06-22") is UTC midnight, which in negative-offset
+      // timezones (e.g. UTC-4) would resolve to June 21 — one day too early.
+      // The fix normalises date-only strings to local noon before parsing.
+      const result = formatDateDayAndDate('2026-06-22');
+      expect(result).toMatch(/6\/22\/2026$/);
+    });
+
+    it('includes the correct day of the week', () => {
+      const result = formatDateDayAndDate('2026-06-22');
+      expect(result).toBe('Monday, 6/22/2026');
+    });
+  });
+
   describe('formatDateForServer', () => {
     describe('happy path — spaced format (MM / DD / YYYY)', () => {
       it('returns YYYY-MM-DD for a standard date', () => {

--- a/src/components/shared/HouseholdForm.tsx
+++ b/src/components/shared/HouseholdForm.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Fragment, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 // Component imports
 import PrimaryInfoFormComponent from '../../Modules/Family/PrimaryInfoFormComponent';
@@ -62,7 +62,8 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
   const modeConfig: FormModeConfig =
     mode === 'registration' ? getRegistrationModeConfig() : getHouseholdSetupModeConfig();
 
-  // Form setup
+  // Form setup — seed preferred_language to 'en' so the Select shows English
+  // on the very first render (before the prefilledData reset effect fires).
   const {
     register,
     trigger,
@@ -72,10 +73,21 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
     watch,
     reset,
     setValue,
-  } = useForm<RegistrationFormData>({ mode: 'onChange' });
+    clearErrors,
+    control,
+  } = useForm<RegistrationFormData>({
+    mode: 'onChange',
+    defaultValues: { preferred_language: 'en' },
+  });
 
-  // Create a wrapper function for watch to match child component expectations
+  // useWatch sets up proper RHF subscriptions that respond to both reset() and
+  // setValue() notifications, unlike watch() called during render which can miss
+  // the setValue notification (its subject payload only carries { name, values }
+  // which doesn't satisfy the root subscriber's form-state check).
   const watchField = watch;
+  const genderWatchValue = useWatch({ control, name: 'gender' }) ?? '';
+  const suffixWatchValue = useWatch({ control, name: 'suffix' }) ?? '';
+  const preferredLanguageWatchValue = useWatch({ control, name: 'preferred_language' }) ?? 'en';
 
   // Component state
   const [state, setState] = useState<HouseholdFormState>({
@@ -296,7 +308,19 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
   };
 
   // Step navigation handlers
-  const continueHandler = (values: Partial<RegistrationFormData>): void => {
+  const continueHandler = async (values: Partial<RegistrationFormData>): Promise<void> => {
+    // In household setup mode, validate required step 1 fields before advancing
+    if (mode === 'householdSetup' && state.formStep === HouseholdFormStep.PRIMARY_INFO) {
+      const isValid = await trigger([
+        'first_name',
+        'last_name',
+        'date_of_birth',
+        'gender',
+        'preferred_language',
+      ]);
+      if (!isValid) return;
+    }
+
     setState((prev) => ({
       ...prev,
       formValues: { ...prev.formValues, ...values },
@@ -340,6 +364,9 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
   };
 
   const previousHandler = (): void => {
+    // Clear any stale validation errors so they don't appear prematurely on the previous step
+    clearErrors();
+
     if (mode === 'householdSetup') {
       // Handle navigation from family member details step
       if (state.formStep === HouseholdFormStep.FAMILY_MEMBER_DETAILS) {
@@ -657,11 +684,15 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
             register={register}
             errors={errors}
             watch={watchField}
+            control={control}
             continueHandler={continueHandler}
             getValues={getValues}
             trigger={trigger}
             setValue={setValue}
             isHouseholdSetup={mode === 'householdSetup'}
+            genderValue={genderWatchValue}
+            suffixValue={suffixWatchValue}
+            preferredLanguageValue={preferredLanguageWatchValue}
           />
         );
 
@@ -985,9 +1016,9 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({
                     {!isFinalStep && state.formStep !== HouseholdFormStep.FAMILY_MEMBER_DETAILS && (
                       <Button
                         type="button"
-                        onClick={() => {
+                        onClick={async () => {
                           const currentValues = getValues();
-                          continueHandler(currentValues);
+                          await continueHandler(currentValues);
                         }}
                         variant="highlight"
                         className="w-full sm:w-auto sm:min-w-48"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches registration prefill timing and household/API vs Cognito merge logic where wrong ordering could show stale or wrong form data; date parsing changes affect displayed and submitted DOB across flows.
> 
> **Overview**
> Fixes **household setup / registration prefill** and **date-of-birth timezone bugs**, and **restructures CI Playwright** for faster, more reliable runs.
> 
> **Registration & household flows:** Cognito users on the RSVP path (no `householdData` in router state) now fetch `/users/me` once, keep a loading gate until prefill finishes, and merge primary-member names plus address/contact prefs. Router-state prefill also fills **first/middle/last name** from the primary member. `HouseholdRegistrationComponent` starts in a loading state, prefers API data over Cognito name splits via a ref, and merges household-level fields when the API returns no members. `PrimaryInfoFormComponent` / `HouseholdForm` use **`useWatch` + `control`** so gender, suffix, and preferred-language Radix selects stay in sync after `reset()`/`setValue()`; household setup validates step 1 (including `preferred_language`) before continue.
> 
> **Dates:** Display and server formatting avoid `new Date("YYYY-MM-DD")` / `toISOString()` shifts; `formatDateForServer` builds `YYYY-MM-DD` directly and rejects impossible calendar dates.
> 
> **CI / E2E:** Single **build** artifact shared by jobs; **one** Cognito auth setup with JWT-validated reuse in CI; **3-way sharded** e2e with blob reports merged to HTML; Playwright **4 workers** in CI and longer waits / `test.slow()` for Firefox/WebKit.
> 
> **Tests & misc:** Broad unit/e2e coverage for prefill and dates; version bump to **3.2.3**; minor test/style cleanups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957e20db16349f9f55df1c2f92ac48213a6cdae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->