### PR TITLE
chore: e2e optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,75 @@ jobs:
           path: dist/
           retention-days: 1
 
+  # Run auth.setup.ts exactly once to produce the Cognito session state.
+  # Uploading it as an artifact lets all three shards reuse it without
+  # triggering additional sign-ins, avoiding Cognito rate-limit collisions.
+  # This job also warms the Playwright browser cache so shards start faster.
+  e2e-setup:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: app-build
+          path: dist/
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium firefox webkit
+
+      - name: Authenticate once
+        run: npx playwright test --project=setup
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:5000
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          REACT_APP_REGISTRATION_API: ${{ vars.REACT_APP_REGISTRATION_API }}
+          REACT_APP_PANTRY_FINDER_API: ${{ vars.REACT_APP_PANTRY_FINDER_API }}
+          REACT_APP_AWS_REGION: ${{ vars.REACT_APP_AWS_REGION }}
+          REACT_APP_USER_POOL_ID: ${{ vars.REACT_APP_USER_POOL_ID }}
+          REACT_APP_USER_POOL_CLIENT_ID: ${{ vars.REACT_APP_USER_POOL_CLIENT_ID }}
+          REACT_APP_CLIENT_URL: ${{ vars.REACT_APP_CLIENT_URL }}
+          REACT_APP_FRESHTRAK_PARTNERS_URL: ${{ vars.REACT_APP_FRESHTRAK_PARTNERS_URL }}
+          REACT_APP_GTM_ID: ${{ vars.REACT_APP_GTM_ID }}
+          REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
+
+      - name: Upload auth state
+        uses: actions/upload-artifact@v6
+        with:
+          name: e2e-auth-state
+          path: e2e/.auth/
+          retention-days: 1
+
   # e2e runs as a 3-way shard matrix so each runner handles ~1/3 of the tests
   # across all three browsers in parallel, cutting wall-clock time by ~60%.
+  # Shards depend on e2e-setup so the Cognito auth state and browser cache are
+  # ready before any shard starts — no redundant sign-ins, no cache misses.
   e2e:
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [lint, test, e2e-setup]
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -84,6 +148,14 @@ jobs:
           name: app-build
           # Restore into dist/ to match Vite's output path expected by vite preview
           path: dist/
+
+      - name: Download auth state
+        uses: actions/download-artifact@v6
+        with:
+          name: e2e-auth-state
+          # Restores user.json to e2e/.auth/ — auth.setup.ts detects the file
+          # and skips re-authentication, preventing concurrent Cognito sign-ins.
+          path: e2e/.auth/
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,10 @@ jobs:
   e2e-setup:
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 10
+    # Worst-case on a cold browser cache: npm ci (~2 min) + playwright install
+    # for three browsers (~4 min) + up to three 180s Cognito login attempts
+    # (~9 min) = ~15 min. 20 minutes gives a comfortable buffer.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -203,11 +206,11 @@ jobs:
   e2e-report:
     runs-on: ubuntu-latest
     needs: e2e
-    # always() is required here. With needs: e2e, GitHub Actions skips
-    # downstream jobs when any matrix shard fails unless always() is used.
-    # !cancelled() is not sufficient — a failed (not cancelled) shard still
-    # causes the default skip behaviour.
-    if: always()
+    # Run when shards finished (success or failure) — both states mean blob
+    # reports were uploaded and can be merged. Explicitly exclude 'skipped'
+    # (e.g. e2e-setup failed so e2e never ran) and 'cancelled' (no artifacts
+    # uploaded), which always() would incorrectly include.
+    if: ${{ needs.e2e.result == 'success' || needs.e2e.result == 'failure' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - run: npm ci
       - run: npm run test:ci
 
-  e2e:
+  # Build the production bundle once and share it with all e2e shards.
+  # This removes the per-shard build cost (~60-90s) from the e2e critical path.
+  build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
-    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -41,8 +41,65 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps chromium firefox webkit
-      - run: npx playwright test
+        env:
+          REACT_APP_REGISTRATION_API: ${{ vars.REACT_APP_REGISTRATION_API }}
+          REACT_APP_PANTRY_FINDER_API: ${{ vars.REACT_APP_PANTRY_FINDER_API }}
+          REACT_APP_AWS_REGION: ${{ vars.REACT_APP_AWS_REGION }}
+          REACT_APP_USER_POOL_ID: ${{ vars.REACT_APP_USER_POOL_ID }}
+          REACT_APP_USER_POOL_CLIENT_ID: ${{ vars.REACT_APP_USER_POOL_CLIENT_ID }}
+          REACT_APP_CLIENT_URL: ${{ vars.REACT_APP_CLIENT_URL }}
+          REACT_APP_FRESHTRAK_PARTNERS_URL: ${{ vars.REACT_APP_FRESHTRAK_PARTNERS_URL }}
+          REACT_APP_GTM_ID: ${{ vars.REACT_APP_GTM_ID }}
+          REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
+          REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
+          REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
+      - uses: actions/upload-artifact@v6
+        with:
+          name: app-build
+          path: build/
+          retention-days: 1
+
+  # e2e runs as a 3-way shard matrix so each runner handles ~1/3 of the tests
+  # across all three browsers in parallel, cutting wall-clock time by ~60%.
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [lint, test, build]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: app-build
+          path: build/
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: pw-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium firefox webkit
+
+      - name: Run Playwright tests (shard ${{ matrix.shard }})
+        run: npx playwright test --shard=${{ matrix.shard }}
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:5000
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
@@ -58,8 +115,40 @@ jobs:
           REACT_APP_IMAGES_BASE_URL: ${{ vars.REACT_APP_IMAGES_BASE_URL }}
           REACT_APP_GOOGLE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_API_KEY }}
           REACT_APP_GOOGLE_GEOLOCATION_KEY: ${{ secrets.REACT_APP_GOOGLE_GEOLOCATION_KEY }}
-      - uses: actions/upload-artifact@v6
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ strategy.job-index }}
+          path: blob-report/
+          retention-days: 1
+
+  # Merge the per-shard blob reports into a single HTML report once all
+  # shards finish (whether they passed or failed).
+  e2e-report:
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: ${{ !cancelled() }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v6
+        with:
+          pattern: blob-report-*
+          merge-multiple: true
+          path: all-blob-reports/
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,11 +195,16 @@ jobs:
 
       - name: Upload blob report
         uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
+        # always() ensures upload runs whether tests passed, failed, or the
+        # shard was cancelled mid-run — partial results are still mergeable.
+        # if-no-files-found: ignore handles the edge case where Playwright
+        # exited before writing any output (e.g. webServer failed to start).
+        if: always()
         with:
           name: blob-report-${{ strategy.job-index }}
           path: blob-report/
           retention-days: 1
+          if-no-files-found: ignore
 
   # Merge the per-shard blob reports into a single HTML report once all
   # shards finish (whether they passed or failed).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: app-build
-          path: build/
+          # Vite outputs to dist/ by default (no custom outDir in vite.config.mts)
+          path: dist/
           retention-days: 1
 
   # e2e runs as a 3-way shard matrix so each runner handles ~1/3 of the tests
@@ -81,7 +82,8 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           name: app-build
-          path: build/
+          # Restore into dist/ to match Vite's output path expected by vite preview
+          path: dist/
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -129,7 +131,11 @@ jobs:
   e2e-report:
     runs-on: ubuntu-latest
     needs: e2e
-    if: ${{ !cancelled() }}
+    # always() is required here. With needs: e2e, GitHub Actions skips
+    # downstream jobs when any matrix shard fails unless always() is used.
+    # !cancelled() is not sufficient — a failed (not cancelled) shard still
+    # causes the default skip behaviour.
+    if: always()
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import { test as setup, expect } from '@playwright/test';
 import { SEL } from '../helpers/selectors';
 import { TEST_USER, AUTH_STATE_PATH, ROUTES } from '../helpers/test-data';
@@ -5,6 +6,13 @@ import { TEST_USER, AUTH_STATE_PATH, ROUTES } from '../helpers/test-data';
 const MAX_LOGIN_ATTEMPTS = 3;
 
 setup('authenticate test user', async ({ page }) => {
+  // In CI the auth state is produced once by the dedicated e2e-setup job and
+  // downloaded as an artifact before each shard starts. Skip re-authentication
+  // to avoid concurrent Cognito sign-ins across shards hitting rate limits.
+  if (existsSync(AUTH_STATE_PATH)) {
+    return;
+  }
+
   setup.setTimeout(180_000);
 
   for (let attempt = 1; attempt <= MAX_LOGIN_ATTEMPTS; attempt++) {

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -9,7 +9,10 @@ setup('authenticate test user', async ({ page }) => {
   // In CI the auth state is produced once by the dedicated e2e-setup job and
   // downloaded as an artifact before each shard starts. Skip re-authentication
   // to avoid concurrent Cognito sign-ins across shards hitting rate limits.
-  if (existsSync(AUTH_STATE_PATH)) {
+  //
+  // The CI guard is intentional: locally we always perform a fresh login so
+  // a leftover file with expired tokens never silently breaks the test run.
+  if (process.env.CI && existsSync(AUTH_STATE_PATH)) {
     return;
   }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,10 +12,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  // Run one worker per browser project in CI (chromium, firefox, webkit).
-  // Locally Playwright auto-selects based on CPU count.
-  workers: process.env.CI ? 3 : undefined,
-  reporter: [['html', { open: 'never' }], ['list']],
+  // 4 workers per shard. ubuntu-latest has 4 vCPUs and e2e tests are largely
+  // I/O-bound (network, navigation waits), so 4 concurrent workers saturates
+  // the runner without CPU contention.
+  workers: process.env.CI ? 4 : undefined,
+  // In CI emit a blob report so the merge job can combine shards into one
+  // HTML report. Locally keep the interactive HTML report.
+  reporter: process.env.CI ? [['blob'], ['list']] : [['html', { open: 'never' }], ['list']],
 
   expect: {
     timeout: 10_000,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes only CI and test harness behavior, but mis-timed auth artifacts or shard/report merge could cause flaky or misleading e2e results without affecting production app code.
> 
> **Overview**
> **Restructures CI e2e** from a single job into a pipeline aimed at shorter wall-clock time and fewer Cognito login collisions.
> 
> A dedicated **`build`** job runs `npm run build` once (with full `REACT_APP_*` env) and uploads **`dist/`** as an artifact. **`e2e-setup`** downloads that bundle, caches/installs Playwright browsers, runs the **`setup`** project once to create auth state, and uploads **`e2e/.auth/`**. **`e2e`** runs as a **3-shard matrix** (`1/3`–`3/3`) after lint, test, and setup; each shard reuses the build and auth artifacts, caches browsers, runs **`playwright test --shard=…`**, and uploads **blob** reports. A new **`e2e-report`** job merges shard blobs into one HTML **`playwright-report`** artifact when shards finish (success or failure).
> 
> **`auth.setup.ts`** skips login in CI when **`AUTH_STATE_PATH`** already exists (artifact from setup); local runs still always authenticate. **`playwright.config.ts`** uses **4 workers** per shard in CI, **blob** reporter in CI (HTML locally), unchanged preview server behavior for CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489da02c5486b29598a9f0df931a1c7f7b640568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->